### PR TITLE
[frontend] Add `eslint-config-prettier`

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next/core-web-vitals"]
+  "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "cypress-multi-reporters": "^1.6.2",
         "eslint": "8.35.0",
         "eslint-config-next": "^13.2.4",
+        "eslint-config-prettier": "^8.7.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.5.0",
         "jest-axe": "^7.0.0",
@@ -4870,6 +4871,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -18078,6 +18091,13 @@
         "eslint-plugin-react": "^7.31.7",
         "eslint-plugin-react-hooks": "^4.5.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "cypress-multi-reporters": "^1.6.2",
     "eslint": "8.35.0",
     "eslint-config-next": "^13.2.4",
+    "eslint-config-prettier": "^8.7.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",
     "jest-axe": "^7.0.0",


### PR DESCRIPTION
Add `eslint-config-prettier` as a dev dependency to prevent conflict between ESLint and Prettier.
    
More information:
- <https://prettier.io/docs/en/integrating-with-linters.html>
- <https://github.com/prettier/eslint-config-prettier>