### PR TITLE
AB#90 Breadcrumb Component

### DIFF
--- a/frontend/__tests__/components/ApplicationNameBar.test.tsx
+++ b/frontend/__tests__/components/ApplicationNameBar.test.tsx
@@ -4,6 +4,19 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 
 import ApplicationNameBar from '../../src/components/ApplicationNameBar'
+import { useRouter } from 'next/router';
+
+// Move useRouter mock to global scope
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+// Apply useRouter mock to all tests
+const useRouterMock = useRouter as jest.Mock<any>;
+useRouterMock.mockReturnValue({
+  pathname: '/home',
+  asPath: '/home',
+});
 
 expect.extend(toHaveNoViolations)
 

--- a/frontend/__tests__/components/Breadcrumb.test.tsx
+++ b/frontend/__tests__/components/Breadcrumb.test.tsx
@@ -4,26 +4,23 @@ import { render, screen } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { useRouter } from 'next/router';
 
-// Mock useRouter hook
+// Move useRouter mock to global scope
 jest.mock('next/router', () => ({
-  useRouter: jest.fn().mockReturnValue({
-    pathname: '/home',
-    asPath: '/home',
-  }),
+  useRouter: jest.fn(),
 }));
 
+// Apply useRouter mock to all tests
+const useRouterMock = useRouter as jest.Mock<any>;
+useRouterMock.mockReturnValue({
+  pathname: '/home',
+  asPath: '/home',
+});
 
 import Breadcrumb from '../../src/components/Breadcrumb'
 
 expect.extend(toHaveNoViolations)
 
 describe('Breadcrumb', () => {
-
-  const useRouterMock = useRouter as jest.Mock<any>;
-
-  beforeEach(() => {
-    useRouterMock.mockClear();
-  });
 
   const sut = <Breadcrumb />
 

--- a/frontend/__tests__/components/Breadcrumb.test.tsx
+++ b/frontend/__tests__/components/Breadcrumb.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
+import Breadcrumb from '../../src/components/Breadcrumb'
+
+expect.extend(toHaveNoViolations)
+
+describe('Breadcrumb', () => {
+
+const sampleItems = [
+    {
+      text: 'Home',
+      link: '/home'
+    },
+    {
+      text: 'Learn',
+      link: '/learn'
+    }
+  ]
+  const sut = <Breadcrumb items={sampleItems} />
+
+  it('renders', () => {
+    render(sut)
+    const screenText = screen.getByText('Home')
+    expect(screenText).toBeInTheDocument()
+  })
+
+  it('meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/__tests__/components/Breadcrumb.test.tsx
+++ b/frontend/__tests__/components/Breadcrumb.test.tsx
@@ -2,6 +2,16 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, screen } from '@testing-library/react'
 
 import { axe, toHaveNoViolations } from 'jest-axe'
+import { useRouter } from 'next/router';
+
+// Mock useRouter hook
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    pathname: '/home',
+    asPath: '/home',
+  }),
+}));
+
 
 import Breadcrumb from '../../src/components/Breadcrumb'
 
@@ -9,21 +19,17 @@ expect.extend(toHaveNoViolations)
 
 describe('Breadcrumb', () => {
 
-const sampleItems = [
-    {
-      text: 'Home',
-      link: '/home'
-    },
-    {
-      text: 'Learn',
-      link: '/learn'
-    }
-  ]
-  const sut = <Breadcrumb items={sampleItems} />
+  const useRouterMock = useRouter as jest.Mock<any>;
+
+  beforeEach(() => {
+    useRouterMock.mockClear();
+  });
+
+  const sut = <Breadcrumb />
 
   it('renders', () => {
     render(sut)
-    const screenText = screen.getByText('Home')
+    const screenText = screen.getByText('Canada.ca')
     expect(screenText).toBeInTheDocument()
   })
 

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -65,6 +65,7 @@
   "found-errors_other": "The following {{count}} errors were found in the form:",
   "francais": "Français",
   "goc": "Government of Canada",
+  "goc-site": "Canada.ca",
   "header": {
     "goc-link": "https://www.canada.ca/en.html",
     "skip-to-main": "Skip to main content"

--- a/frontend/public/locales/en/learn.json
+++ b/frontend/public/locales/en/learn.json
@@ -1,0 +1,3 @@
+{
+    "header": "Learn"
+}

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -65,6 +65,7 @@
   "found-errors_other": "Les {{count}} erreurs suivantes ont été trouvées dans le formulaire\u00A0:",
   "francais": "Français",
   "goc": "Governement du Canada",
+  "goc-site": "Canada.ca",
   "header": {
     "goc-link": "https://www.canada.ca/fr.html",
     "skip-to-main": "Passer au contenu principal"

--- a/frontend/public/locales/fr/learn.json
+++ b/frontend/public/locales/fr/learn.json
@@ -1,0 +1,3 @@
+{
+    "header": "(FR)Learn"
+}

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,45 @@
+import { FC } from 'react'
+import Link from 'next/link'
+
+type BreadcrumbItemType = {
+    text: string;
+    link: string;
+  };
+
+export interface BreadcrumbProps {
+    id?: string;
+    items?: BreadcrumbItemType[];
+}
+
+const Breadcrumb: FC<BreadcrumbProps> = ({ id, items }) => {
+  return (
+    <section className="container mx-auto p-4">
+    <nav aria-label="breadcrumbs" id={id}>
+      <ul className="block text-blue-link font-body">
+        {items
+          ? items.map((item, index) => {
+              return (
+                <li
+                  key={`list-${index}`}
+                  className={`inline-block w-100 pb-4 sm:pb-0`}
+                >
+                  <Link
+                    href={item.link}
+                    className="font-body hover:text-canada-footer-hover-font-blue text-blue-link underline"
+                  >
+                    {item.text}
+                  </Link>
+                  {index < items.length - 1 && (
+                    <span className="mx-2 inline-block align-middle text-blue-link pr-2 pl-2">{'>'}</span>
+                  )}
+                </li>
+              );
+            })
+          : null}
+      </ul>
+    </nav>
+</section>
+  )
+}
+
+export default Breadcrumb

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -52,7 +52,7 @@ const Breadcrumb: FC = () => {
           href={t('header.goc-link')}
           className="font-body hover:text-blue-hover text-blue-link underline"
           >
-          {t('goc-site')}
+          Canada.ca
           </Link>
           {breadcrumbs.length > 0 && (
             <span className="mx-2 inline-block align-middle text-blue-link pr-2 pl-2">{'>'}</span>

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,23 +1,65 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next'
 
 type BreadcrumbItemType = {
     text: string;
     link: string;
   };
 
-export interface BreadcrumbProps {
-    id?: string;
-    items?: BreadcrumbItemType[];
-}
+const Breadcrumb: FC = () => {
 
-const Breadcrumb: FC<BreadcrumbProps> = ({ id, items }) => {
+  const { t } = useTranslation('common')
+  const router = useRouter();
+  const [breadcrumbs, setBreadcrumbs] = useState<Array<BreadcrumbItemType> | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (router) {
+      const linkPath = router.asPath.split('/');
+      linkPath.shift();
+
+      linkPath.pop();
+      const pathArray = linkPath.map((path, i) => {
+        const formattedPath = path.charAt(0).toUpperCase() + path.slice(1)
+        .split("-")
+        .join(" ");
+        return {
+          text: formattedPath,
+          link: '/' + linkPath.slice(0, i + 1).join('/'),
+        };
+      });
+
+      setBreadcrumbs(pathArray);
+    }
+  }, [router]);
+
+  if (!breadcrumbs) {
+    return null;
+  } 
+
   return (
     <section className="container mx-auto p-4">
-    <nav aria-label="breadcrumbs" id={id}>
+    <nav aria-label="breadcrumbs">
       <ul className="block text-blue-link font-body">
-        {items
-          ? items.map((item, index) => {
+      <li
+        key={`list-canada`}
+        className={`inline-block w-100 pb-4 sm:pb-0`}
+        >
+          <Link
+          href={t('header.goc-link')}
+          className="font-body hover:text-blue-hover text-blue-link underline"
+          >
+          {t('goc-site')}
+          </Link>
+          {breadcrumbs.length > 0 && (
+            <span className="mx-2 inline-block align-middle text-blue-link pr-2 pl-2">{'>'}</span>
+          )}
+      </li>
+        {breadcrumbs
+          && breadcrumbs.map((item, index) => {
               return (
                 <li
                   key={`list-${index}`}
@@ -25,17 +67,17 @@ const Breadcrumb: FC<BreadcrumbProps> = ({ id, items }) => {
                 >
                   <Link
                     href={item.link}
-                    className="font-body hover:text-canada-footer-hover-font-blue text-blue-link underline"
+                    className="font-body hover:text-blue-hover text-blue-link underline"
                   >
                     {item.text}
                   </Link>
-                  {index < items.length - 1 && (
+                  {index < breadcrumbs.length - 1 && (
                     <span className="mx-2 inline-block align-middle text-blue-link pr-2 pl-2">{'>'}</span>
                   )}
                 </li>
               );
             })
-          : null}
+            }
       </ul>
     </nav>
 </section>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,13 +8,20 @@ import { useRouter } from 'next/router'
 
 import ApplicationNameBar from './ApplicationNameBar'
 import Banner from './Banner'
+import Breadcrumb from './Breadcrumb'
+
+type BreadcrumbItemType = {
+  text: string;
+  link: string;
+};
 
 export interface HeaderProps {
   gocLink: string
   skipToMainText: string
+  breadCrumbItems: BreadcrumbItemType[];
 }
 
-const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
+const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadCrumbItems }) => {
   const config = getConfig()
   const { locale, asPath } = useRouter()
   const { t } = useTranslation('common')
@@ -115,12 +122,10 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
           ]}
         /> */}
 
-        {/* Place Holder for the breadcrumbs
-
         <div className="layout-container my-2">
-          <Breadcrumb items={breadcrumbItems} />
+          <Breadcrumb items={breadCrumbItems} />
         </div>
-        */}
+      
       </header>
     </>
   )

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,18 +10,12 @@ import ApplicationNameBar from './ApplicationNameBar'
 import Banner from './Banner'
 import Breadcrumb from './Breadcrumb'
 
-type BreadcrumbItemType = {
-  text: string;
-  link: string;
-};
-
 export interface HeaderProps {
   gocLink: string
   skipToMainText: string
-  breadCrumbItems: BreadcrumbItemType[];
 }
 
-const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadCrumbItems }) => {
+const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
   const config = getConfig()
   const { locale, asPath } = useRouter()
   const { t } = useTranslation('common')
@@ -123,7 +117,7 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadCrumbItems }) =
         /> */}
 
         <div className="layout-container my-2">
-          <Breadcrumb items={breadCrumbItems} />
+          <Breadcrumb />
         </div>
       
       </header>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,17 +5,25 @@ import { useTranslation } from 'next-i18next'
 import Footer from './Footer'
 import Header from './Header'
 
+type BreadcrumbItemType = {
+  text: string;
+  link: string;
+};
+
 export interface LayoutProps {
   children: ReactNode
+  breadCrumbItems: BreadcrumbItemType[];
 }
 
-const Layout: FC<LayoutProps> = ({ children }) => {
+
+const Layout: FC<LayoutProps> = ({ children, breadCrumbItems }) => {
   const { t } = useTranslation('common')
   return (
     <div className="flex min-h-screen flex-col">
       <Header
         skipToMainText={t('header.skip-to-main')}
         gocLink={t('header.goc-link')}
+        breadCrumbItems={breadCrumbItems}
       />
       <main
         role="main"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,25 +5,18 @@ import { useTranslation } from 'next-i18next'
 import Footer from './Footer'
 import Header from './Header'
 
-type BreadcrumbItemType = {
-  text: string;
-  link: string;
-};
-
 export interface LayoutProps {
   children: ReactNode
-  breadCrumbItems: BreadcrumbItemType[];
 }
 
 
-const Layout: FC<LayoutProps> = ({ children, breadCrumbItems }) => {
+const Layout: FC<LayoutProps> = ({ children }) => {
   const { t } = useTranslation('common')
   return (
     <div className="flex min-h-screen flex-col">
       <Header
         skipToMainText={t('header.skip-to-main')}
         gocLink={t('header.goc-link')}
-        breadCrumbItems={breadCrumbItems}
       />
       <main
         role="main"

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -71,11 +71,13 @@ const MyApp = ({ Component, pageProps, router }: AppProps) => {
 
       <DefaultSeo {...nextSEOConfig} />
       <QueryClientProvider client={queryClient}>
-        <Layout
-        breadCrumbItems={pageProps.breadCrumbItems}
-        >
-        <Component {...pageProps} />
-        </Layout>
+      {router.pathname === '/' ? (
+          <Component {...pageProps} />
+        ) : (
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        )}
       </QueryClientProvider>
     </>
   )

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { AppProps } from 'next/app'
 import getConfig from 'next/config'
 import Head from 'next/head'
 import Script from 'next/script'
+import Layout from '../components/Layout'
 
 import { AppWindow } from '../lib/types'
 import { getNextSEOConfig } from '../next-seo.config'
@@ -70,7 +71,11 @@ const MyApp = ({ Component, pageProps, router }: AppProps) => {
 
       <DefaultSeo {...nextSEOConfig} />
       <QueryClientProvider client={queryClient}>
+        <Layout
+        breadCrumbItems={pageProps.breadCrumbItems}
+        >
         <Component {...pageProps} />
+        </Layout>
       </QueryClientProvider>
     </>
   )

--- a/frontend/src/pages/_error.tsx
+++ b/frontend/src/pages/_error.tsx
@@ -1,4 +1,6 @@
 import { NextPage } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { GetServerSideProps } from 'next'
 
 import Error404Page from '../components/error-pages/Error404Page'
 import ErrorPage from '../components/error-pages/ErrorPage'
@@ -12,9 +14,11 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
   return <ErrorPage statusCode={statusCode} />
 }
 
-Error.getInitialProps = async ({ res, err }) => {
-  const statusCode = res?.statusCode ?? err?.statusCode ?? 404
-  return { statusCode }
-}
+export const getServerSideProps: GetServerSideProps = async ({ res, locale }) => ({
+  props: {
+    statusCode: res?.statusCode ?? 404,
+    ...(await serverSideTranslations(locale ?? 'default', ['common', 'home'])),
+  },
+})
 
 export default Error

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -7,8 +7,6 @@ import { NextSeo } from 'next-seo'
 import Link from 'next/link'
 import Image from 'next/image'
 
-import Layout from '../components/Layout'
-
 
 export interface SupportingSeniorsCardProps {
   src: string,
@@ -22,7 +20,7 @@ return (
   <div className="flex flex-col border rounded-md shadow-lg p-4">
 
       <div className="h-[300px] mx-auto">
-          <Image 
+          <Image
               src={src}
               width={200}
               height={300}
@@ -39,7 +37,7 @@ const Home: FC = () => {
   const { t } = useTranslation('home')
 
   return (
-    <Layout>
+    <div>
       <NextSeo title={t('header')} />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
@@ -107,7 +105,7 @@ const Home: FC = () => {
           <Link className="text-lg" href={t('contact-us.cards.find-office.href')}>{t('contact-us.cards.find-office.link-text')}</Link>
         </div>
       </section>
-    </Layout>
+    </div>
   )
 }
 

--- a/frontend/src/pages/home/learn.tsx
+++ b/frontend/src/pages/home/learn.tsx
@@ -19,34 +19,9 @@ const Learn: FC = () => {
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
 
-  const breadCrumbItems = (locale === 'en' ?
-  [
-      {
-        "text": "Home",
-        "link": "/home"
-      },
-      {
-        "text": "Learn",
-        "link": "/learn"
-      }
-  ]
-  :
-  [
-      {
-        "text": "(FR)Home",
-        "link": "/home"
-      },
-      {
-        "text": "(FR)Learn",
-        "link": "/learn"
-      }
-  ] 
-  )
-
   return{
     props: {
       ...(await serverSideTranslations(locale ?? 'default', ['common', 'learn'])),
-      breadCrumbItems: breadCrumbItems
     }
   }
 }

--- a/frontend/src/pages/learn.tsx
+++ b/frontend/src/pages/learn.tsx
@@ -1,0 +1,54 @@
+import { FC } from 'react'
+
+import { GetServerSideProps } from 'next'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { NextSeo } from 'next-seo'
+
+const Learn: FC = () => {
+  const { t } = useTranslation('learn')
+  return (
+    <div>
+      <NextSeo title={t('header')} />
+      <h1 className="h1">{t('header')}</h1>
+    </div>
+  )
+}
+
+
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+
+  const breadCrumbItems = (locale === 'en' ?
+  [
+      {
+        "text": "Home",
+        "link": "/home"
+      },
+      {
+        "text": "Learn",
+        "link": "/learn"
+      }
+  ]
+  :
+  [
+      {
+        "text": "(FR)Home",
+        "link": "/home"
+      },
+      {
+        "text": "(FR)Learn",
+        "link": "/learn"
+      }
+  ] 
+  )
+
+  return{
+    props: {
+      ...(await serverSideTranslations(locale ?? 'default', ['common', 'learn'])),
+      breadCrumbItems: breadCrumbItems
+    }
+  }
+}
+
+export default Learn

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -45,7 +45,6 @@
     @apply font-bold;
     @apply font-display;
     @apply text-4xl;
-    @apply mt-9;
     @apply mb-8;
     @apply text-aqua-default;
   }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
           dark: '#26374a',
           deep: '#2e5274',
           active: '#16446c',
+          link: '#284162',
         },
         gray: {
           light: '#e1e4e7',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -43,6 +43,7 @@ module.exports = {
           deep: '#2e5274',
           active: '#16446c',
           link: '#284162',
+          hover: '#0535D2',
         },
         gray: {
           light: '#e1e4e7',


### PR DESCRIPTION
## [ADO-90](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/90)

### Description

List of proposed changes:

- Added Breadcrumb component and Unit Test
- Added "Learn" page to display the component
- Breadcrumbs are automatically generated through React Router. This will only generate breadcrumbs for pages with sub-routes ex. /en/home/learn will have breadcrumbs while /en/learn will not (this can be revisited)
- Error pages were not getting server side translations, this has been resolved

### What to test for/How to test

### Additional Notes
- Pulled this in for Sprint 2