### PR TITLE
fix prettier-plugin-tailwindcss installation

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -10,5 +10,11 @@
     "^[./]"
   ],
   "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "importOrderSortSpecifiers": true,
+  "plugins": [
+    "@trivago/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
+  ],
+  "pluginSearchDirs": false,
+  "tailwindConfig": "./tailwind.config.js"
 }


### PR DESCRIPTION
### Description

List of proposed changes:

- Fix prettier-plugin-tailwindcss installation

### What to test for/How to test

### Additional Notes

I noticed when running prettier on a file that `prettier-plugin-tailwindcss` wasn't applied. I added the plugins to Prettier config explicitly and it fixed the issue.

https://github.com/tailwindlabs/prettier-plugin-tailwindcss

Automatic Class Sorting with Prettier
https://tailwindcss.com/blog/automatic-class-sorting-with-prettier