### PR TITLE
move Layout in each pages

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -7,7 +7,6 @@ import { AppProps } from 'next/app'
 import getConfig from 'next/config'
 import Head from 'next/head'
 import Script from 'next/script'
-import Layout from '../components/Layout'
 
 import { AppWindow } from '../lib/types'
 import { getNextSEOConfig } from '../next-seo.config'
@@ -71,13 +70,7 @@ const MyApp = ({ Component, pageProps, router }: AppProps) => {
 
       <DefaultSeo {...nextSEOConfig} />
       <QueryClientProvider client={queryClient}>
-      {router.pathname === '/' ? (
-          <Component {...pageProps} />
-        ) : (
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        )}
+        <Component {...pageProps} />
       </QueryClientProvider>
     </>
   )

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -6,6 +6,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 import Link from 'next/link'
+import Layout from 'src/components/Layout'
 import Tabcordian from 'src/components/Tabcordian'
 
 export interface SupportingSeniorsCardProps {
@@ -38,7 +39,7 @@ const Home: FC = () => {
   const { t } = useTranslation('home')
 
   return (
-    <div>
+    <Layout>
       <NextSeo title={t('header')} />
 
       <section className="flex flex-col rounded-2xl bg-[#f5f5f5] p-5 md:relative md:p-0">
@@ -130,7 +131,7 @@ const Home: FC = () => {
           </Link>
         </div>
       </section>
-    </div>
+    </Layout>
   )
 }
 

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -6,11 +6,12 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 import Link from 'next/link'
+import Layout from 'src/components/Layout'
 
 const Learn: FC = () => {
   const { t } = useTranslation('learn')
   return (
-    <div>
+    <Layout>
       <NextSeo title={t('header')} />
       <section className="rounded-2xl bg-[#f5f5f5]">
         <div className="flex flex-col items-center md:flex-row-reverse">
@@ -44,7 +45,7 @@ const Learn: FC = () => {
           </Link>
         </div>
       </section>
-    </div>
+    </Layout>
   )
 }
 

--- a/frontend/src/pages/learn/retirement-income-sources.tsx
+++ b/frontend/src/pages/learn/retirement-income-sources.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
+import Layout from 'src/components/Layout'
 
 export interface ImportantCardProps extends PropsWithChildren {}
 const ImportantCard: FC<ImportantCardProps> = ({ children }) => (
@@ -15,7 +16,7 @@ const RetirementIncomeSources: FC = () => {
   const { t } = useTranslation('learn/retirement-income-sources')
 
   return (
-    <>
+    <Layout>
       <NextSeo title={t('header')} />
       <h1 className="mb-10 rounded-3xl bg-[#212121]/[.08] px-4 py-6 font-display text-4xl font-medium text-primary-700 md:mb-12 md:px-24 md:py-16 md:text-5xl md:font-bold">
         {t('header')}
@@ -436,7 +437,7 @@ const RetirementIncomeSources: FC = () => {
           </div>
         </Link>
       ))}
-    </>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
### Description

List of proposed changes:

- move Layout in each pages
- remove Layout from _app

### What to test for/How to test

### Additional Notes

Each page is expected to manage its own layout, although most pages (about 98%) will likely use the Layout component. However, there are exceptions, such as error and landing pages. Currently, the conditional rendering of the Layout component in the _app is causing issues with error pages that use the ErrorLayout component. Additionally, if a page needs to pass props to the Layout component, such as breadcrumb items, this would not be feasible if the component is placed in _app.

![image](https://user-images.githubusercontent.com/114004123/230147113-dc73dcb7-cbea-4d10-9336-50a23eeb6057.png)
