### PR TITLE
[frontend] fix fonts import

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import createEmotionCache from '../createEmotionCache'
 import { AppWindow } from '../lib/types'
 import { getNextSEOConfig } from '../next-seo.config'
 import '../styles/globals.css'
+import '../styles/latofonts.css'
 import theme from '../theme'
 import { createCounter } from '../utils/metrics'
 

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -132,6 +132,17 @@ export default function MyDocument({
       <Head nonce={nonce}>
         <meta charSet="utf-8" />
         <link rel="icon" href="/assets/favicon.ico" />
+        {/** Google font **/}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap&family=Patua+One:wght@100;400;700&display=swap"
+          rel="stylesheet"
+        />
         <meta name="emotion-insertion-point" content="" />
         {emotionStyleTags}
       </Head>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,7 +1,3 @@
-/* ensure that there is.link semicolon.linkt the end of the line otherwise the styles will not build correctly in production.  */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap&family=Patua+One:wght@100;400;700&display=swap');
-@import "latofonts.css";
-
 /* tailwind default */
 @tailwind base;
 


### PR DESCRIPTION
### Description

List of proposed changes:

- fix fonts import because `Noto Sans` was not rendered a `Arial` is used instead.

### What to test for/How to test

### Additional Notes

![image](https://user-images.githubusercontent.com/114004123/234002778-e081ec51-c464-4f6b-8f80-fe883ef091ba.png)
