### PR TITLE
AB#140 and Quiz Question 2

### DIFF
--- a/frontend/public/locales/en/learn.json
+++ b/frontend/public/locales/en/learn.json
@@ -26,6 +26,22 @@
       "retirement": "<strong>retirement plan</strong> (when you plan on retiring, where you plan on living in retirement, etc.)",
       "timetocomplete": "Time to complete survey",
       "minutes": "3 minutes"
+    },
+    "questions":{
+      "question-2": {
+        "question-1": {
+          "title": "Select all that apply to you. You are...",
+          "option-1": "Single",
+          "option-2": "Married or common-law",
+          "option-3": "Divorced or separated",
+          "option-4": "Widowed"
+        },
+        "question-2": {
+          "title": "Do you have children?",
+          "option-1": "Yes",
+          "option-2": "No"
+        }
+      }
     }
   },
   "sections": [

--- a/frontend/public/locales/fr/learn.json
+++ b/frontend/public/locales/fr/learn.json
@@ -26,6 +26,22 @@
       "retirement": "(FR) <strong>retirement plan</strong> (when you plan on retiring, where you plan on living in retirement, etc.)",
       "timetocomplete": "(FR) Time to complete survey",
       "minutes": "(FR) 3 minutes"
+    },
+    "questions":{
+      "question-2": {
+        "question-1": {
+          "title": "(FR) Select all that apply to you. You are...",
+          "option-1": "(FR) Single",
+          "option-2": "(FR) Married or common-law",
+          "option-3": "(FR) Divorced or separated",
+          "option-4": "(FR) Widowed"
+        },
+        "question-2": {
+          "title": "(FR) Do you have children?",
+          "option-1": "(FR) Yes",
+          "option-2": "(FR) No"
+        }
+      }
     }
   },
   "sections": [

--- a/frontend/src/components/questions/Question2.tsx
+++ b/frontend/src/components/questions/Question2.tsx
@@ -1,10 +1,48 @@
-const Question2 = () => {
-    return (
-     <div>
-        <h5>Select all that apply to you. You are...</h5>
-     </div>
-    );
-  };
+import { Checkbox, FormControlLabel, FormGroup, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+type QuestionProps = {
+   values: { [field: string]: any },
+   setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void
+}
+
+const Question2 = ({ values, setFieldValue }: QuestionProps) => {
+   
+   let {t} = useTranslation('learn')
+
+   function handleChangeManually(e: React.ChangeEvent<any>, toggleOff?: string){
+      let field = e.target.value
+      setFieldValue(field, values[field] ? '' : field)
+      if (toggleOff) setFieldValue(toggleOff,'')
+   }
+
+   return (
+      <div>
+         <h5 className="h5">{t('quiz.questions.question-2.question-1.title')}</h5>
+         <FormGroup className="mb-2" onChange={handleChangeManually}> 
+            <FormControlLabel control={<Checkbox name='maritalStatus' value='single' />} label={t('quiz.questions.question-2.question-1.option-1')}/>
+            <FormControlLabel control={<Checkbox name='maritalStatus' value='marriedOrCommonLaw' />} label={t('quiz.questions.question-2.question-1.option-2')} />
+            <FormControlLabel control={<Checkbox name='maritalStatus' value='divorcedOrSeparated' />} label={t('quiz.questions.question-2.question-1.option-3')} />
+            <FormControlLabel control={<Checkbox name='maritalStatus' value='widowed' />} label={t('quiz.questions.question-2.question-1.option-4')} />
+         </FormGroup>
+         <h5 className="h5 mb-2">{t('quiz.questions.question-2.question-2.title')}</h5>
+         <ToggleButtonGroup
+            color='primary'
+            orientation="vertical"
+            exclusive
+            fullWidth
+            className="mb-10"
+            >
+               <ToggleButton name='children' value="yesChildren" aria-label={t('quiz.questions.question-2.question-2.option-1')} selected={values['yesChildren']} onClick={e=>handleChangeManually(e,'noChildren')}>
+                  {t('quiz.questions.question-2.question-2.option-1')}
+               </ToggleButton>
+               <ToggleButton name='children' value="noChildren" aria-label={t('quiz.questions.question-2.question-2.option-2')} selected={values['noChildren']} onClick={e=>handleChangeManually(e,'yesChildren')}>
+                  {t('quiz.questions.question-2.question-2.option-2')}
+               </ToggleButton>
+            </ToggleButtonGroup>
+      </div>
+   );
+};
   
   export default Question2;
   

--- a/frontend/src/lib/steps/StepLookupTable.ts
+++ b/frontend/src/lib/steps/StepLookupTable.ts
@@ -1,0 +1,59 @@
+// lookup table for mapping quiz answer IDs to step IDs for checklist page
+
+import { FormValues } from "../../pages/learn"
+
+export interface TableMapping {
+   [question: string]: {[answerID: string]: string[]} 
+}
+
+export const StepLookupTable: TableMapping = {
+    "question-1": {
+
+    },
+    "question-2": {
+        "base": ["base1","base2"],
+        "single": ["single1","single2","single3"],
+        "marriedOrCommonLaw": ["marriedOrCommonLaw1"],
+        "divorcedOrSeparated": ["divorcedOrSeparated1","divorcedOrSeparated2"],
+        "widowed": ["widowed1","widowed2"],
+        "yesChildren": ["yesChildren1"],
+        "noChildren": ["noChildren1","noChildren2"],
+    },
+    "question-3": {
+
+    },
+    "question-4": {
+
+    },
+    "question-5": {
+
+    },
+    "question-6": {
+
+    },
+    "question-7": {
+
+    },
+    "question-8": {
+
+    },
+    "question-9": {
+
+    },
+}
+
+
+
+// example usage 
+export function getStepsFromQuizState(state: FormValues): string[] {
+    // filter out empty (not selected) answers
+    // "base" steps will always be included in the results for each question
+    let answerIDs = Object.values(state).flat().filter(Boolean)
+    let steps = []
+    for (let questionSteps of Object.values(StepLookupTable)){
+        for (let [answerID,stepArray] of Object.entries(questionSteps)){
+            if (answerID==='base' || answerIDs.includes(answerID)) steps.push(...stepArray)
+        }
+    }
+    return steps
+}

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -37,8 +37,8 @@ export interface FormValues {
   marriedOrCommonLaw: string,
   divorcedOrSeparated: string,
   widowed: string,
-  yesChildren: '',
-  noChildren: ''
+  yesChildren: string,
+  noChildren: string,
 }
 
 

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -31,6 +31,17 @@ import Question7 from '../../components/questions/Question7'
 import Question8 from '../../components/questions/Question8'
 import Question9 from '../../components/questions/Question9'
 
+
+export interface FormValues {
+  single: string,
+  marriedOrCommonLaw: string,
+  divorcedOrSeparated: string,
+  widowed: string,
+  yesChildren: '',
+  noChildren: ''
+}
+
+
 const Learn: FC = () => {
   const { t } = useTranslation('learn')
   const sections = t<string, { cards: any[] }[]>('sections', {
@@ -49,6 +60,15 @@ const Learn: FC = () => {
 
   const [, setFinalValues] = useState({})
   const [, setFinished] = useState(false)
+
+  const initialValues: FormValues = {
+    single: '',
+    marriedOrCommonLaw: '',
+    divorcedOrSeparated: '',
+    widowed: '',
+    yesChildren: '',
+    noChildren: ''
+  }
 
   return (
     <Layout>
@@ -108,7 +128,7 @@ const Learn: FC = () => {
               </h2>
             </div>
             <FormikWizard
-              initialValues={{}}
+              initialValues={initialValues}
               onSubmit={(values) => {
                 setFinalValues(values)
                 setFinished(true)


### PR DESCRIPTION
## [ADO-140](https://dev.azure.com/JourneyLab/SeniorsJourney/_sprints/taskboard/DTS/SeniorsJourney/DTS/DTS%20-%20Sprint%204?workitem=140)

### Description

The suggested workflow for how the quiz state can be used for the results (checklist) page:

    - the quiz state is captured using Formik in the initialValues prop
    - users will interact with the quiz and the state changes will be handled by Formik
    - the quiz state captures the answerID that the user selected
    - upon submitting the quiz the state can be pushed to session/local storage to use throughout the application, or can be managed by a global store via the Context API
    - a lookup table will subsequently be used to map answerIDs found in state to the stepIDs that should be rendered to the user on the checklist page. 
    - a set of 'base' steps is also rendered regardless of whether the user selected a particular answer
    - the base steps are maintained in the lookup table as well


List of proposed changes:

- add lookup table to support mapping between quiz state and 'step' results for checklist page
- implement Question 2 component
- add translations

### What to test for/How to test

- open the quiz and ensure question 2 options work in terms of selecting and un-selecting
- optionally test the lookup table to see how step IDs can be mapped to answer IDs from the quiz state

### Additional Notes

I have never used Formik and I'm pretty nooby in terms of MUI.  I'm certain this PR will have lots of comments and requested changes.  Please let me know of any anti-patterns that exist in this PR. 