### PR TITLE
correct the from-work-to-retirement page section title

### DIFF
--- a/frontend/public/locales/en/learn/from-work-to-retirement.json
+++ b/frontend/public/locales/en/learn/from-work-to-retirement.json
@@ -1,5 +1,5 @@
 {
-    "header": "When to take your pensions",
+    "header": "From work to retirement",
     "key-takeaways": {
         "heading": "Key Takeaways",
         "list": {


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/xxx)

### Description
The incorrect from work to retirement page section EN title caused confusion if the link for index learning page was incorrect. The link is correct but the section title was not. Corrected the section title.

List of proposed changes:
- Changed the section title to "From work to retirement"

### What to test for/How to test
npm i
npm run dev
got to http://localhost:3000/en/learn
click on the "From work to retirement" panel

### Additional Notes