### PR TITLE
add window.btoa to remove deprecation warning

### DIFF
--- a/frontend/src/pages/quiz/tasks/[[...filters]].tsx
+++ b/frontend/src/pages/quiz/tasks/[[...filters]].tsx
@@ -70,7 +70,7 @@ const Tasks: FC<TasksProps> = ({ applyingBenefits, beforeRetiring, filters, rece
     if (!filters) filters = {}
     if (e.target.checked) filters.tags = [...(filters?.tags ?? []), e.target.value]
     else filters.tags = (filters?.tags ?? []).filter((tag) => tag !== e.target.value)
-    const encodedFilters = encodeURIComponent(btoa(JSON.stringify(filters)))
+    const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
     router.push(`/quiz/tasks/${encodedFilters}`)
   }
 


### PR DESCRIPTION
The node btoa function is deprecated.  Adding window.btoa makes it more explicit and this only runs client side.