### PR TITLE
add logic for handling quiz in local storage

### DIFF
--- a/frontend/src/components/ApplicationNameBar.tsx
+++ b/frontend/src/components/ApplicationNameBar.tsx
@@ -3,24 +3,27 @@ import { FC } from 'react'
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import { Button, Link as MuiLink } from '@mui/material'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
-import {Breadcrumb, BreadcrumbItem } from './Breadcrumb'
+import { Breadcrumb, BreadcrumbItem } from './Breadcrumb'
 
 export interface ApplicationNameBarProps {
   text: string
   href: string
   checklist: string
   checklistUrl: string
-  breadcrumbItems?: BreadcrumbItem[];
+  breadcrumbItems?: BreadcrumbItem[]
 }
 
-const ApplicationNameBar: FC<ApplicationNameBarProps> = ({
-  text,
-  href,
-  checklist,
-  checklistUrl,
-  breadcrumbItems,
-}) => {
+const ApplicationNameBar: FC<ApplicationNameBarProps> = ({ text, href, checklist, checklistUrl, breadcrumbItems }) => {
+  let router = useRouter()
+
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault()
+    let encodedFilters = localStorage.getItem('quiz')
+    router.push(encodedFilters === null ? `/${router.locale}/learn` : `/quiz/tasks/${encodedFilters}`)
+  }
+
   return (
     <div id="app-bar">
       <section className="container mx-auto p-4">
@@ -34,14 +37,18 @@ const ApplicationNameBar: FC<ApplicationNameBarProps> = ({
           >
             <h2>{text}</h2>
           </MuiLink>
-          <Button
-            component={Link}
-            href={checklistUrl}
-            startIcon={<BookmarkBorderIcon />}
-            size="large"
-          >
-            {checklist}
-          </Button>
+          {router.pathname !== '/quiz/tasks/[[...filters]]' && (
+            <Button
+              component={Link}
+              href={checklistUrl}
+              startIcon={<BookmarkBorderIcon />}
+              size="large"
+              onClick={handleClick}
+              disabled={!router.isReady}
+            >
+              {checklist}
+            </Button>
+          )}
         </div>
         <Breadcrumb items={breadcrumbItems} />
       </section>

--- a/frontend/src/components/ApplicationNameBar.tsx
+++ b/frontend/src/components/ApplicationNameBar.tsx
@@ -1,9 +1,8 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import { Button, Link as MuiLink } from '@mui/material'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 
 import { Breadcrumb, BreadcrumbItem } from './Breadcrumb'
 
@@ -13,16 +12,17 @@ export interface ApplicationNameBarProps {
   checklist: string
   checklistUrl: string
   breadcrumbItems?: BreadcrumbItem[]
+  hideChecklist?: boolean
 }
 
-const ApplicationNameBar: FC<ApplicationNameBarProps> = ({ text, href, checklist, checklistUrl, breadcrumbItems }) => {
-  let router = useRouter()
-
-  function handleClick(e: React.MouseEvent) {
-    e.preventDefault()
-    let encodedFilters = localStorage.getItem('quiz')
-    router.push(encodedFilters === null ? `/${router.locale}/learn` : `/quiz/tasks/${encodedFilters}`)
-  }
+const ApplicationNameBar: FC<ApplicationNameBarProps> = ({ text, href, checklist, breadcrumbItems, hideChecklist }) => {
+  let [checklistUrl, setChecklistUrl] = useState<string>('/learn')
+  useEffect(() => {
+    let quiz = localStorage.getItem('quiz')
+    if (quiz === null) return
+    let encodedFilters = encodeURIComponent(window.btoa(quiz ?? ''))
+    setChecklistUrl(`/quiz/tasks/${encodedFilters}`)
+  }, [])
 
   return (
     <div id="app-bar">
@@ -37,15 +37,8 @@ const ApplicationNameBar: FC<ApplicationNameBarProps> = ({ text, href, checklist
           >
             <h2>{text}</h2>
           </MuiLink>
-          {router.pathname !== '/quiz/tasks/[[...filters]]' && (
-            <Button
-              component={Link}
-              href={checklistUrl}
-              startIcon={<BookmarkBorderIcon />}
-              size="large"
-              onClick={handleClick}
-              disabled={!router.isReady}
-            >
+          {!hideChecklist && (
+            <Button component={Link} href={checklistUrl} startIcon={<BookmarkBorderIcon />} size="large">
               {checklist}
             </Button>
           )}

--- a/frontend/src/components/ApplicationNameBar.tsx
+++ b/frontend/src/components/ApplicationNameBar.tsx
@@ -2,8 +2,10 @@ import { FC, useEffect, useState } from 'react'
 
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import { Button, Link as MuiLink } from '@mui/material'
+import { compact } from 'lodash'
 import Link from 'next/link'
 
+import { Filters } from '../pages/quiz/tasks/[[...filters]]'
 import { Breadcrumb, BreadcrumbItem } from './Breadcrumb'
 
 export interface ApplicationNameBarProps {
@@ -16,12 +18,19 @@ export interface ApplicationNameBarProps {
 }
 
 const ApplicationNameBar: FC<ApplicationNameBarProps> = ({ text, href, checklist, breadcrumbItems, hideChecklist }) => {
-  let [checklistUrl, setChecklistUrl] = useState<string>('/learn')
+  let [checklistUrl, setChecklistUrl] = useState('/learn')
+
   useEffect(() => {
-    let quiz = localStorage.getItem('quiz')
-    if (quiz === null) return
-    let encodedFilters = encodeURIComponent(window.btoa(quiz ?? ''))
-    setChecklistUrl(`/quiz/tasks/${encodedFilters}`)
+    // try to get stored quiz form values
+    try {
+      const storedFormValues = JSON.parse(localStorage.getItem('quiz') ?? '')
+      const filters: Filters = { answers: compact(Object.values<string>(storedFormValues)) }
+      // Encodes a js object as a url-safe base64 string.
+      const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
+      setChecklistUrl(`/quiz/tasks/${encodedFilters}`)
+    } catch (err) {
+      return
+    }
   }, [])
 
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,14 +12,14 @@ import ApplicationNameBar from './ApplicationNameBar'
 import Banner from './Banner'
 import { BreadcrumbItem } from './Breadcrumb'
 
-
 export interface HeaderProps {
   gocLink: string
   skipToMainText: string
-  breadcrumbItems?: BreadcrumbItem[];
+  breadcrumbItems?: BreadcrumbItem[]
+  hideChecklist?: boolean
 }
 
-const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadcrumbItems }) => {
+const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadcrumbItems, hideChecklist }) => {
   const config = getConfig()
   const { locale, query, pathname } = useRouter()
   const { t } = useTranslation('common')
@@ -47,23 +47,14 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadcrumbItems }) =
       </nav>
 
       <header>
-        {showBanner && (
-          <Banner
-            alert={t('banner.alert')}
-            description={t('banner.description')}
-          />
-        )}
+        {showBanner && <Banner alert={t('banner.alert')} description={t('banner.description')} />}
         <div className="container mx-auto flex flex-col justify-between px-4 py-2.5 md:flex md:flex-row">
           <div className="flex flex-row content-center items-center justify-between md:mt-7">
             <a href={gocLink}>
               <Image
                 key={locale}
                 className="h-7 w-auto lg:h-8"
-                alt={
-                  locale === 'en'
-                    ? 'Government of Canada'
-                    : 'Gouvernement du Canada'
-                }
+                alt={locale === 'en' ? 'Government of Canada' : 'Gouvernement du Canada'}
                 src={`/assets/sig-blk-${locale}.svg`}
                 width={300}
                 height={28}
@@ -110,6 +101,7 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText, breadcrumbItems }) =
           checklist={t('checklist')}
           checklistUrl={t('checklist-url')}
           breadcrumbItems={breadcrumbItems}
+          hideChecklist={hideChecklist}
         />
 
         {/* <Menu

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,22 +2,28 @@ import { FC, ReactNode } from 'react'
 
 import { useTranslation } from 'next-i18next'
 
+import { BreadcrumbItem } from './Breadcrumb'
 import Container from './Container'
 import Footer from './Footer'
 import Header from './Header'
-import { BreadcrumbItem } from './Breadcrumb'
 
 export interface LayoutProps {
   children: ReactNode
-  breadcrumbItems?: BreadcrumbItem[];
+  breadcrumbItems?: BreadcrumbItem[]
   contained?: boolean
+  hideChecklist?: boolean
 }
 
-const Layout: FC<LayoutProps> = ({ children, contained, breadcrumbItems }) => {
+const Layout: FC<LayoutProps> = ({ children, contained, breadcrumbItems, hideChecklist }) => {
   const { t } = useTranslation('common')
   return (
     <div className="flex min-h-screen flex-col">
-      <Header skipToMainText={t('header.skip-to-main')} gocLink={t('header.goc-link')} breadcrumbItems={breadcrumbItems} />
+      <Header
+        skipToMainText={t('header.skip-to-main')}
+        gocLink={t('header.goc-link')}
+        breadcrumbItems={breadcrumbItems}
+        hideChecklist={hideChecklist}
+      />
       <main role="main" id="mainContent" className="mt-5 flex-1 pb-8">
         {contained ? <Container>{children}</Container> : <>{children}</>}
       </main>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -140,12 +140,14 @@ const Learn: FC = () => {
   }
 
   return (
-      <Layout breadcrumbItems={[
+    <Layout
+      breadcrumbItems={[
         {
-          link: t("breadcrumbs.home.link"), 
-          text: t("breadcrumbs.home.text")
-        }
-      ]}>
+          link: t('breadcrumbs.home.link'),
+          text: t('breadcrumbs.home.text'),
+        },
+      ]}
+    >
       <NextSeo title={t('header')} />
       <h1 className="sr-only">{t('header')}</h1>
       <section className="rounded-3xl bg-[#f5f5f5] ">
@@ -187,6 +189,9 @@ const Learn: FC = () => {
               const filters: Filters = { answers: compact(Object.values<string>(values)) }
               // Encodes a js object as a url-safe base64 string.
               const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
+
+              localStorage.setItem('quiz', encodedFilters)
+
               router.push(`/quiz/tasks/${encodedFilters}`)
             }}
             validateOnNext

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -189,9 +189,7 @@ const Learn: FC = () => {
               const filters: Filters = { answers: compact(Object.values<string>(values)) }
               // Encodes a js object as a url-safe base64 string.
               const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
-
-              localStorage.setItem('quiz', encodedFilters)
-
+              localStorage.setItem('quiz', JSON.stringify(filters))
               router.push(`/quiz/tasks/${encodedFilters}`)
             }}
             validateOnNext

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 
 import CloseIcon from '@mui/icons-material/Close'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
@@ -12,11 +12,11 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  MobileStepper,
+  LinearProgress,
   useMediaQuery,
   useTheme,
 } from '@mui/material'
-import { FormikWizard } from 'formik-wizard-form'
+import { useFormikWizard } from 'formik-wizard-form'
 import { compact } from 'lodash'
 import { GetServerSideProps } from 'next'
 import { useTranslation } from 'next-i18next'
@@ -39,7 +39,7 @@ import Question8 from '../../components/questions/Question8'
 import { Filters } from '../quiz/tasks/[[...filters]]'
 
 // TODO: map form values to "answer-id" from locales/(en/fr)/quiz/tasks/task-list.json once it has been finalized
-export interface FormValues {
+export interface QuizFormState {
   retirementAge: string
   single: string
   marriedOrCommonLaw: string
@@ -52,6 +52,21 @@ export interface FormValues {
   legalStatus: string
   yearsInCanada: string
   hasCppDisabilityBenefits: string
+}
+
+const defaultFormValues: QuizFormState = {
+  retirementAge: '',
+  single: '',
+  marriedOrCommonLaw: '',
+  divorcedOrSeparated: '',
+  widowed: '',
+  hasChildren: '',
+  financialPreparedness: '',
+  retirementTimeframe: '',
+  hasExtraIncome: '',
+  legalStatus: '',
+  yearsInCanada: '',
+  hasCppDisabilityBenefits: '',
 }
 
 export interface QuizConfirmationProps {
@@ -110,7 +125,11 @@ const Learn: FC = () => {
 
   const handleCloseModal = () => {
     if (showConfirmation) {
+      // remove stored form state
+      localStorage.removeItem('quiz')
+
       setIsModalOpen(false)
+
       // 1 second timeout otherwise dialog shows quiz content and close
       setTimeout(function () {
         setShowConfirmation(false)
@@ -124,20 +143,46 @@ const Learn: FC = () => {
     setShowConfirmation(false)
   }
 
-  const initialValues: FormValues = {
-    retirementAge: '',
-    single: '',
-    marriedOrCommonLaw: '',
-    divorcedOrSeparated: '',
-    widowed: '',
-    hasChildren: '',
-    financialPreparedness: '',
-    retirementTimeframe: '',
-    hasExtraIncome: '',
-    legalStatus: '',
-    yearsInCanada: '',
-    hasCppDisabilityBenefits: '',
-  }
+  const initialValues = useMemo<QuizFormState>(() => {
+    // check if it's server side
+    if (typeof window === 'undefined') return defaultFormValues
+
+    // try to get and merge stored quiz form values
+    try {
+      const storedFormValues = JSON.parse(localStorage.getItem('quiz') ?? '')
+      return { ...defaultFormValues, ...storedFormValues }
+    } catch (err) {
+      return defaultFormValues
+    }
+  }, [])
+
+  const formikWizard = useFormikWizard({
+    initialValues: initialValues,
+    onSubmit: (values) => {
+      const filters: Filters = { answers: compact(Object.values<string>(values)) }
+      // Encodes a js object as a url-safe base64 string.
+      const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
+      router.push(`/quiz/tasks/${encodedFilters}`)
+    },
+    validateOnNext: true,
+    activeStepIndex: 0,
+    steps: [
+      { component: QuizLandingPage },
+      { component: Question1 },
+      { component: Question2 },
+      { component: Question3 },
+      { component: Question4 },
+      { component: Question5 },
+      { component: Question6 },
+      { component: Question7 },
+      { component: Question8 },
+    ],
+  })
+
+  useEffect(() => {
+    // store any form values changes in locale storage
+    localStorage.setItem('quiz', JSON.stringify(formikWizard.values))
+  }, [formikWizard.values])
 
   return (
     <Layout
@@ -183,107 +228,69 @@ const Learn: FC = () => {
             noText={t('quiz.confirmation.no')}
           />
         ) : (
-          <FormikWizard
-            initialValues={initialValues}
-            onSubmit={(values) => {
-              const filters: Filters = { answers: compact(Object.values<string>(values)) }
-              // Encodes a js object as a url-safe base64 string.
-              const encodedFilters = encodeURIComponent(window.btoa(JSON.stringify(filters)))
-              localStorage.setItem('quiz', JSON.stringify(filters))
-              router.push(`/quiz/tasks/${encodedFilters}`)
-            }}
-            validateOnNext
-            activeStepIndex={0}
-            steps={[
-              {
-                component: QuizLandingPage,
-              },
-              {
-                component: Question1,
-              },
-              {
-                component: Question2,
-              },
-              {
-                component: Question3,
-              },
-              {
-                component: Question4,
-              },
-              {
-                component: Question5,
-              },
-              {
-                component: Question6,
-              },
-              {
-                component: Question7,
-              },
-              {
-                component: Question8,
-              },
-            ]}
-          >
-            {({ currentStepIndex, renderComponent, handlePrev, handleNext, isNextDisabled, isPrevDisabled }) => {
-              return (
-                <div className="flex min-h-[850px] flex-col">
-                  <DialogTitle className="text-right">
-                    <Button variant="text" onClick={handleCloseModal} startIcon={<CloseIcon />} size="large">
-                      {t('quiz.navigation.close')}
-                    </Button>
-                  </DialogTitle>
-                  <DialogContent className="flex flex-col">
-                    <h2 className="mb-8 font-display text-2xl font-medium md:mb-16 md:rounded-3xl md:bg-[#f5f5f5] md:p-6 md:text-4xl md:text-primary-700">
-                      {t('quiz.navigation.title')}
-                    </h2>
-                    <div className="mb-5">{renderComponent()}</div>
-                    {(currentStepIndex ?? 0) > 0 && (
-                      <div className="mt-auto">
-                        <MobileStepper
-                          variant="progress"
-                          steps={9}
-                          position="static"
-                          activeStep={currentStepIndex}
-                          backButton={undefined}
-                          nextButton={undefined}
-                          classes={{
-                            progress: 'w-full',
-                          }}
-                        />
-                        <p className="m-0 text-center">
-                          {currentStepIndex} {t('quiz.navigation.of')} 8
-                        </p>
-                      </div>
-                    )}
-                  </DialogContent>
-                  <DialogActions className="block">
-                    {currentStepIndex === 0 ? (
-                      <Button onClick={handleNext} disabled={isNextDisabled} size="large" fullWidth autoFocus>
-                        {t('quiz.navigation.start')}
+          <>
+            <div className="flex min-h-[850px] flex-col">
+              <DialogTitle className="text-right">
+                <Button variant="text" onClick={handleCloseModal} startIcon={<CloseIcon />} size="large">
+                  {t('quiz.navigation.close')}
+                </Button>
+              </DialogTitle>
+              <DialogContent className="flex flex-col">
+                <h2 className="mb-8 font-display text-2xl font-medium md:mb-16 md:rounded-3xl md:bg-[#f5f5f5] md:p-6 md:text-4xl md:text-primary-700">
+                  {t('quiz.navigation.title')}
+                </h2>
+                <div className="mb-5">{formikWizard.renderComponent()}</div>
+                {!formikWizard.isFirstStep && (
+                  <div className="mt-auto">
+                    <LinearProgress
+                      variant="determinate"
+                      value={((formikWizard.currentStepIndex ?? 0) / 8) * 100}
+                      aria-labelledby="progress-label"
+                      className="my-2"
+                    />
+                    <p id="progress-label" className="m-0 text-center">
+                      {formikWizard.currentStepIndex} {t('quiz.navigation.of')} 8
+                    </p>
+                  </div>
+                )}
+              </DialogContent>
+              <DialogActions className="block">
+                {formikWizard.isFirstStep ? (
+                  <Button
+                    onClick={formikWizard.handleNext}
+                    disabled={formikWizard.isNextDisabled}
+                    size="large"
+                    fullWidth
+                    autoFocus
+                  >
+                    {t('quiz.navigation.start')}
+                  </Button>
+                ) : (
+                  <>
+                    <div className="grid gap-2 md:grid-cols-2 md:gap-6">
+                      <Button
+                        onClick={formikWizard.handlePrev}
+                        disabled={formikWizard.isPrevDisabled}
+                        size="large"
+                        fullWidth
+                        variant="outlined"
+                      >
+                        {t('quiz.navigation.previous')}
                       </Button>
-                    ) : (
-                      <>
-                        <div className="grid gap-2 md:grid-cols-2 md:gap-6">
-                          <Button
-                            onClick={handlePrev}
-                            disabled={isPrevDisabled}
-                            size="large"
-                            fullWidth
-                            variant="outlined"
-                          >
-                            {t('quiz.navigation.previous')}
-                          </Button>
-                          <Button onClick={handleNext} disabled={isNextDisabled} size="large" fullWidth>
-                            {currentStepIndex === 8 ? t('quiz.navigation.submit') : t('quiz.navigation.next')}
-                          </Button>
-                        </div>
-                      </>
-                    )}
-                  </DialogActions>
-                </div>
-              )
-            }}
-          </FormikWizard>
+                      <Button
+                        onClick={formikWizard.handleNext}
+                        disabled={formikWizard.isNextDisabled}
+                        size="large"
+                        fullWidth
+                      >
+                        {formikWizard.isLastStep ? t('quiz.navigation.submit') : t('quiz.navigation.next')}
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </DialogActions>
+            </div>
+          </>
         )}
       </Dialog>
 

--- a/frontend/src/pages/quiz/tasks/[[...filters]].tsx
+++ b/frontend/src/pages/quiz/tasks/[[...filters]].tsx
@@ -74,13 +74,21 @@ const Tasks: FC<TasksProps> = ({ applyingBenefits, beforeRetiring, filters, rece
     router.push(`/quiz/tasks/${encodedFilters}`)
   }
 
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault()
+    localStorage.removeItem('quiz')
+    router.push(`/${router.locale}/learn`)
+  }
+
   return (
-    <Layout breadcrumbItems={[
-      {
-        link: t("breadcrumbs.home.link"), 
-        text: t("breadcrumbs.home.text")
-      }
-    ]}>
+    <Layout
+      breadcrumbItems={[
+        {
+          link: t('breadcrumbs.home.link'),
+          text: t('breadcrumbs.home.text'),
+        },
+      ]}
+    >
       <div className="grid gap-6 lg:grid-cols-12">
         <section className="lg:col-span-4 lg:block xl:col-span-3">
           <div className="mb-4 text-right">
@@ -91,6 +99,7 @@ const Tasks: FC<TasksProps> = ({ applyingBenefits, beforeRetiring, filters, rece
               startIcon={<RefreshIcon />}
               size="large"
               className="w-full md:w-auto lg:w-full"
+              onClick={handleClick}
             >
               {t('restart-quiz')}
             </Button>

--- a/frontend/src/pages/quiz/tasks/[[...filters]].tsx
+++ b/frontend/src/pages/quiz/tasks/[[...filters]].tsx
@@ -77,11 +77,12 @@ const Tasks: FC<TasksProps> = ({ applyingBenefits, beforeRetiring, filters, rece
   function handleClick(e: React.MouseEvent) {
     e.preventDefault()
     localStorage.removeItem('quiz')
-    router.push(`/${router.locale}/learn`)
+    router.push('/learn')
   }
 
   return (
     <Layout
+      hideChecklist={true}
       breadcrumbItems={[
         {
           link: t('breadcrumbs.home.link'),


### PR DESCRIPTION
### Description

The checklist button should navigate users to the checklist page if they've submitted a quiz.  If they haven't and they click on the button, they should be navigated to the learn page.  

While on the checklist page, if a user clicks the restart quiz button, they will be redirected to the learn page and all memory of the completed quiz will be removed from storage.


List of proposed changes:

- add logic to persist encoded quiz filters to local storage
- upon clicking the checklist button, check local storage to see if there are persisted quiz filters
- if yes, user is directed to the checklist page
- if no, user is directed to learn page
- reset quiz button on checklist page clears local storage and directs user to learn page
