### PR TITLE
[frontend] add responsive overflow to tables

### DIFF
--- a/frontend/src/components/AccessibilityTable.tsx
+++ b/frontend/src/components/AccessibilityTable.tsx
@@ -15,29 +15,31 @@ interface TableProps {
 
 const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
   return (
-    <table className="min-w-full border-collapse divide-y border text-left">
-      <caption className="text-left pb-4">{tableData.caption}</caption>
-      <thead className="bg-gray-surface">
-        <tr className="divide-x">
-          {tableData.header.map((headerItem, index) => (
-            <th scope="col" key={index} className="px-3 py-2.5">
-              {headerItem}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody className="divide-y">
-        {tableData.rows.map((row) => (
-          <tr key={row.id} className="divide-x">
-            {row.data.map((cellData, cellIndex) => (
-              <td key={cellIndex} className="px-3 py-2.5">
-                {cellData}
-              </td>
+    <div className='overflow-x-scroll w-full'>
+      <table className="whitespace-nowrap min-w-full border-collapse divide-y border text-left">
+        <caption className="text-left">{tableData.caption}</caption>
+        <thead className="bg-gray-surface">
+          <tr className="divide-x">
+            {tableData.header.map((headerItem, index) => (
+              <th scope="col" key={index} className="px-3 py-2.5">
+                {headerItem}
+              </th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody className="divide-y">
+          {tableData.rows.map((row) => (
+            <tr key={row.id} className="divide-x">
+              {row.data.map((cellData, cellIndex) => (
+                <td key={cellIndex} className="px-3 py-2.5">
+                  {cellData}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 

--- a/frontend/src/components/LearnPageLayout.tsx
+++ b/frontend/src/components/LearnPageLayout.tsx
@@ -21,11 +21,11 @@ export const LearnPageLayout: FC<LearnPageLayoutProps> = ({ children, header, br
       <h1 className="mb-10 rounded-3xl bg-gray-surface px-4 py-6 font-display text-4xl font-medium text-primary-700 md:mb-12 md:px-10 md:py-10 md:text-6xl md:font-bold">
         {header}
       </h1>
-      <div className="grid gap-6 lg:grid-cols-12">
+      <div className="sm:grid sm:gap-6 lg:grid-cols-12">
         <section className="hidden lg:col-span-4 lg:block xl:col-span-3">
           {!tableOfContentsData.loading && <TableOfContents {...tableOfContentsData} />}
         </section>
-        <section className="sticky top-4 z-10 ml-auto lg:hidden">
+        <section className="flex justify-end sticky top-4 z-10 ml-auto lg:hidden">
           {!tableOfContentsData.loading && <TableOfContentsDialog {...tableOfContentsData} />}
         </section>
         <section id="content" className="lg:col-span-8 xl:col-span-9">


### PR DESCRIPTION
Add responsive container around a11y tables to ensure they're scrollable at smaller viewport widths.