### PR TITLE
[frontend] fix AB#387

### DIFF
--- a/frontend/src/components/quiz/QuizDialog.tsx
+++ b/frontend/src/components/quiz/QuizDialog.tsx
@@ -20,14 +20,14 @@ import { useRouter } from 'next/router'
 import { useSetQuizData } from '../../lib/hooks/useSetQuizData'
 import { ChecklistFilters } from '../../pages/checklist/[filters]'
 import { QuizLanding } from './QuizLanding'
-import { QuestionWhen } from './questions/QuestionWhen'
 import { QuestionApply } from './questions/QuestionApply'
-import { QuestionFeelPrepared } from './questions/QuestionFeelPrepared'
-import { QuestionWhere } from './questions/QuestionWhere'
-import { QuestionEarn } from './questions/QuestionEarn'
-import { QuestionStatus } from './questions/QuestionStatus'
-import { QuestionHowLong } from './questions/QuestionHowLong'
 import { QuestionDisabilityBenefits } from './questions/QuestionDisabilityBenefits'
+import { QuestionEarn } from './questions/QuestionEarn'
+import { QuestionFeelPrepared } from './questions/QuestionFeelPrepared'
+import { QuestionHowLong } from './questions/QuestionHowLong'
+import { QuestionStatus } from './questions/QuestionStatus'
+import { QuestionWhen } from './questions/QuestionWhen'
+import { QuestionWhere } from './questions/QuestionWhere'
 
 // TODO: map form values to "answer-id" from locales/(en/fr)/quiz/tasks/task-list.json once it has been finalized
 export interface QuizFormState extends Record<string, string> {
@@ -70,7 +70,15 @@ export interface QuizConfirmationProps {
   yesID: string
 }
 
-export const QuizConfirmation: FC<QuizConfirmationProps> = ({ noText, noID, onCancel, onClose, sureText, yesText, yesID }) => {
+export const QuizConfirmation: FC<QuizConfirmationProps> = ({
+  noText,
+  noID,
+  onCancel,
+  onClose,
+  sureText,
+  yesText,
+  yesID,
+}) => {
   return (
     <>
       <DialogContent>
@@ -93,12 +101,11 @@ export const QuizConfirmation: FC<QuizConfirmationProps> = ({ noText, noID, onCa
   )
 }
 
-export interface QuizDialogProps {
+interface QuizDialogWizardProps {
   onClose: () => void
-  open: boolean
 }
 
-export const QuizDialog: FC<QuizDialogProps> = ({ onClose, open }) => {
+const QuizDialogWizard: FC<QuizDialogWizardProps> = ({ onClose }) => {
   const router = useRouter()
   const { t } = useTranslation('quiz')
   const theme = useTheme()
@@ -150,7 +157,7 @@ export const QuizDialog: FC<QuizDialogProps> = ({ onClose, open }) => {
   return (
     <Dialog
       onClose={handleOnClose}
-      open={open}
+      open={true}
       aria-labelledby={`${showConfirmation ? 'quiz-modal-close-confirmation' : 'quiz-modal-header'}`}
       scroll="body"
       fullScreen={fullScreen}
@@ -171,7 +178,13 @@ export const QuizDialog: FC<QuizDialogProps> = ({ onClose, open }) => {
         <>
           <div className="flex min-h-[850px] flex-col" data-cy={t('navigation.id')}>
             <DialogTitle className="text-right" id="quiz-modal-header">
-              <Button data-cy={t('navigation.close.id')} variant="text" onClick={handleOnClose} startIcon={<CloseIcon />} size="large">
+              <Button
+                data-cy={t('navigation.close.id')}
+                variant="text"
+                onClick={handleOnClose}
+                startIcon={<CloseIcon />}
+                size="large"
+              >
                 {t('navigation.close.text')}
               </Button>
             </DialogTitle>
@@ -238,4 +251,17 @@ export const QuizDialog: FC<QuizDialogProps> = ({ onClose, open }) => {
       )}
     </Dialog>
   )
+}
+
+export interface QuizDialogProps {
+  onClose: () => void
+  open: boolean
+}
+
+export const QuizDialog: FC<QuizDialogProps> = ({ onClose, open }) => {
+  /**
+   * Conditionally render QuizDialogWizard to always start with new states
+   */
+  if (open) return <QuizDialogWizard onClose={onClose} />
+  return null
 }


### PR DESCRIPTION
## [AB#387](https://dev.azure.com/JourneyLab/e5439067-4cca-4d9d-9c04-19430d3be3db/_workitems/edit/387)

### Description

List of proposed changes:

- fix: Closing quiz - Answers retained as long as user stays on learning page after closing quiz but will not produce a checklist if submitted. FormikWizard have a way to reset the form start but not the active step. I rendered the `QuizDialogWizard` conditionally to have a fresh state when the dialog is opening.

### What to test for/How to test

### Additional Notes