### PR TITLE
[frontend] save quiz data in sessionStorage

### DIFF
--- a/frontend/src/lib/hooks/useQuizData.ts
+++ b/frontend/src/lib/hooks/useQuizData.ts
@@ -7,7 +7,7 @@ import { getLogger } from '../../logging/log-util'
 const logger = getLogger('useQuizData')
 
 /**
- * Retrieves Quiz stored data from localStorage
+ * Retrieves Quiz stored data from sessionStorage
  * @returns null if no data stored or it can't be parsed else a QuizFormState object
  */
 export const useQuizData = (options?: UseQueryOptions<QuizFormState | null>) => {
@@ -15,7 +15,7 @@ export const useQuizData = (options?: UseQueryOptions<QuizFormState | null>) => 
     ['quiz'],
     () => {
       try {
-        const data = localStorage.getItem('quiz')
+        const data = sessionStorage.getItem('quiz')
         return data === null || isEmpty(data) ? null : JSON.parse(data)
       } catch (err) {
         logger.warn(err, 'Problem occured when parsing quiz stored data')

--- a/frontend/src/lib/hooks/useRemoveQuizData.ts
+++ b/frontend/src/lib/hooks/useRemoveQuizData.ts
@@ -1,14 +1,14 @@
 import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query'
 
 /**
- * Removes Quiz data from localStorage
+ * Removes Quiz data from sessionStorage
  */
 export const useRemoveQuizData = (options?: UseMutationOptions) => {
   const queryClient = useQueryClient()
   return useMutation(
     ['quiz'],
     async () => {
-      localStorage.removeItem('quiz')
+      sessionStorage.removeItem('quiz')
       queryClient.removeQueries(['quiz'])
     },
     options

--- a/frontend/src/lib/hooks/useSetQuizData.ts
+++ b/frontend/src/lib/hooks/useSetQuizData.ts
@@ -3,14 +3,14 @@ import { UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react
 import { QuizFormState } from '../../components/quiz/QuizDialog'
 
 /**
- * Stores Quiz data in localStorage
+ * Stores Quiz data in sessionStorage
  */
 export const useSetQuizData = (options?: UseMutationOptions<void, unknown, QuizFormState>) => {
   const queryClient = useQueryClient()
   return useMutation<void, unknown, QuizFormState>(
     ['quiz'],
     async (data) => {
-      localStorage.setItem('quiz', JSON.stringify(data))
+      sessionStorage.setItem('quiz', JSON.stringify(data))
       queryClient.setQueryData<QuizFormState>(['quiz'], (old) => ({ ...old, ...data }))
     },
     options


### PR DESCRIPTION
## [AB#272](https://dev.azure.com/JourneyLab/e5439067-4cca-4d9d-9c04-19430d3be3db/_workitems/edit/272)

### Description

List of proposed changes:

- save quiz data in sessionStorage (instead of localeStorage)

### What to test for/How to test

### Additional Notes