### PR TITLE
[frontend] change id to match heading in TOC

### DIFF
--- a/frontend/src/pages/learn/case-studies/bonnie.tsx
+++ b/frontend/src/pages/learn/case-studies/bonnie.tsx
@@ -221,7 +221,7 @@ const Bonnie: FC = () => {
           valuesHeading={t('values-heading')}
         />
 
-        <h2 id="early-pension" className="h2">
+        <h2 id="conclusion" className="h2">
           {t('conclusion.heading')}
         </h2>
         <p>{t('conclusion.p1')}</p>


### PR DESCRIPTION
Fixing a typo in the ID for a heading in the TOC on Bonnie's case study.  

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/9fabb74c-e629-489b-9236-d7755295c6f6)
