### PR TITLE
[frontend] change styles

### DIFF
--- a/frontend/src/components/AccessibilityTable.tsx
+++ b/frontend/src/components/AccessibilityTable.tsx
@@ -16,7 +16,7 @@ interface TableProps {
 const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
   return (
     <div className='overflow-x-scroll w-full'>
-      <table className="whitespace-nowrap min-w-full border-collapse divide-y border text-left">
+      <table className="min-w-full border-collapse divide-y border text-left">
         <caption className="text-left">{tableData.caption}</caption>
         <thead className="bg-gray-surface">
           <tr className="divide-x">

--- a/frontend/src/pages/learn/case-studies/keith.tsx
+++ b/frontend/src/pages/learn/case-studies/keith.tsx
@@ -149,7 +149,7 @@ const Keith: FC = () => {
           {t('cpp.cpp-choices.heading')}
         </h2>
         <Img pension="cpp.cpp-choices" />
-        <div className="grid grid-cols-1 py-4 text-center md:grid-cols-2">
+        <div className="grid grid-cols-1 py-4 md:text-center md:grid-cols-2">
           <div>
             <p>{t('cpp.cpp-choices.choices.li1')}</p>
             <p>{t('cpp.cpp-choices.choices.li2')}</p>
@@ -211,7 +211,7 @@ const Keith: FC = () => {
           <Trans ns="learn/case-studies/fred" i18nKey={t(`cpp.keith-pension-87.p3`)} />
         </p>
         <Img pension="cpp.keith-pension-87" />
-        <div className="grid grid-cols-1 py-4 text-center md:grid-cols-2">
+        <div className="grid grid-cols-1 py-4 md:text-center md:grid-cols-2">
           <div>
             <p>{t('cpp.keith-pension-87.choices.li1')}</p>
             <p>{t('cpp.keith-pension-87.choices.li2')}</p>
@@ -235,7 +235,7 @@ const Keith: FC = () => {
         </h2>
         <p>{t('cpp.keith-pension-90.p1')}</p>
         <Img pension="cpp.keith-pension-90" />
-        <div className="grid grid-cols-1 py-4 text-center md:grid-cols-2">
+        <div className='grid md:grid-cols-2 grid-cols-1 md:text-center py-4'>
           <div>
             <p>{t('cpp.keith-pension-90.choices.li1')}</p>
             <p>{t('cpp.keith-pension-90.choices.li2')}</p>


### PR DESCRIPTION
Modify styles such that the "choices" text is left aligned on smaller screen instead of centred per the mockups.  Also remove the whitespace-nowrap on the accessibility table headers since it's still causing overflow on viewports around the 1000px width.   