### PR TITLE
[frontend] rename Explore public pensions to Explore retirement

### DIFF
--- a/frontend/__tests__/components/Footer.test.tsx
+++ b/frontend/__tests__/components/Footer.test.tsx
@@ -49,8 +49,8 @@ describe('Footer', () => {
             linkText: 'some-link-4',
           },
         ]}
-        explorePublicPensionsText="learning materials text"
-        explorePublicPensionsLinks={[
+        exploreRetirementText="learning materials text"
+        exploreRetirementLinks={[
           {
             link: 'https://some-link-1.com',
             linkText: 'some-link-1',
@@ -93,8 +93,8 @@ describe('Footer', () => {
           },
         ]}
         footerNavHeader="testFooterNavHeader"
-        explorePublicPensionsText="learning materials text"
-        explorePublicPensionsLinks={[
+        exploreRetirementText="learning materials text"
+        exploreRetirementLinks={[
           {
             link: 'https://some-link-1.com',
             linkText: 'some-link-1',

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -11,8 +11,8 @@
     "canada-ca-alt-text": "Symbol of the Government of Canada",
     "header": "Retirement Hub",
     "nav-header": "Government of Canada Corporate",
-    "explore-public-pensions-text": "Explore public pensions",
-    "explore-public-pensions": {
+    "explore-retirement-text": "Explore retirement",
+    "explore-retirement": {
       "going-from-work-to-retirement": "Going from work to retirement",
       "main-sources-of-retirement-income": "Main sources of retirement income",
       "planning-to-save-for-retirement": "Planning to save for retirement",

--- a/frontend/public/locales/fr/common.json
+++ b/frontend/public/locales/fr/common.json
@@ -11,8 +11,8 @@
     "canada-ca-alt-text": "Symbole du gouvernement du Canada",
     "header": "Carrefour retraite",
     "nav-header": "Organisation du gouvernement du Canada",
-    "explore-public-pensions-text": "Renseignez-vous sur la retraite",
-    "explore-public-pensions": {
+    "explore-retirement-text": "Renseignez-vous sur la retraite",
+    "explore-retirement": {
       "going-from-work-to-retirement": "Transition du monde du travail à la retraite",
       "main-sources-of-retirement-income": "Principales sources de revenus de retraite",
       "planning-to-save-for-retirement": "Planifiez pour épargner en vue de la retraite",

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -35,12 +35,12 @@ export interface FooterProps {
   /**
    * Learning Matierials Header for appropriate menu
    */
-  explorePublicPensionsText: string
+  exploreRetirementText: string
 
   /**
    * array of objects containing the Learning materials link text and link
    */
-  explorePublicPensionsLinks: FooterLink[]
+  exploreRetirementLinks: FooterLink[]
 
   /**
    * Menu Header for appropriate menu
@@ -80,8 +80,8 @@ const Footer: FC<FooterProps> = ({
   footerHeader,
   footerLogo,
   footerNavHeader,
-  explorePublicPensionsLinks,
-  explorePublicPensionsText,
+  exploreRetirementLinks,
+  exploreRetirementText,
   links,
   menuLinks,
   menuText,
@@ -95,9 +95,9 @@ const Footer: FC<FooterProps> = ({
           <h2 className="mb-8 font-display font-bold md:text-lg">{footerHeader}</h2>
           <div className="grid gap-6 md:grid-cols-3">
             <div>
-              <h3 className="mb-4 font-display font-medium md:text-xl">{explorePublicPensionsText}</h3>
+              <h3 className="mb-4 font-display font-medium md:text-xl">{exploreRetirementText}</h3>
               <ul className="space-y-2 text-sm">
-                {explorePublicPensionsLinks.map(({ link, linkText }) => (
+                {exploreRetirementLinks.map(({ link, linkText }) => (
                   <li key={link}>
                     <MuiLink component={Link} color="inherit" underline="hover" href={link}>
                       {linkText}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -57,27 +57,27 @@ const Layout: FC<LayoutProps> = ({ children, contained, breadcrumbItems, hideFoo
               linkText: t('footer.links.privacy'),
             },
           ]}
-          explorePublicPensionsText={t('footer.explore-public-pensions-text')}
-          explorePublicPensionsLinks={[
+          exploreRetirementText={t('footer.explore-retirement-text')}
+          exploreRetirementLinks={[
             {
               link: '/learn/main-sources-of-retirement-income',
-              linkText: t('footer.explore-public-pensions.main-sources-of-retirement-income'),
+              linkText: t('footer.explore-retirement.main-sources-of-retirement-income'),
             },
             {
               link: '/learn/planning-to-save-for-retirement',
-              linkText: t('footer.explore-public-pensions.planning-to-save-for-retirement'),
+              linkText: t('footer.explore-retirement.planning-to-save-for-retirement'),
             },
             {
               link: '/learn/deciding-when-to-collect-public-pensions',
-              linkText: t('footer.explore-public-pensions.when-to-collect-public-pensions'),
+              linkText: t('footer.explore-retirement.when-to-collect-public-pensions'),
             },
             {
               link: '/learn/going-from-work-to-retirement',
-              linkText: t('footer.explore-public-pensions.going-from-work-to-retirement'),
+              linkText: t('footer.explore-retirement.going-from-work-to-retirement'),
             },
             {
               link: '/learn/rules-of-thumb-for-public-pensions',
-              linkText: t('footer.explore-public-pensions.rules-of-thumb-for-public-pensions'),
+              linkText: t('footer.explore-retirement.rules-of-thumb-for-public-pensions'),
             },
           ]}
           menuText={t('footer.menu-text')}


### PR DESCRIPTION
## [AB#272](https://dev.azure.com/JourneyLab/e5439067-4cca-4d9d-9c04-19430d3be3db/_workitems/edit/272)

### Description

List of proposed changes:

- rename `Explore public pensions` to `Explore retirement`

### What to test for/How to test

### Additional Notes