### PR TITLE
[frontend] checklist page overflow issue on mobile/french

### DIFF
--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -115,7 +115,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
           </div>
         </section>
 
-        <div className="grid gap-6 print:block lg:grid-cols-12">
+        <div className="print:block sm:grid sm:gap-6 lg:grid-cols-12">
           <section className="print:hidden lg:col-span-4 lg:block xl:col-span-3">
             <div className="mb-4 text-right">
               <Button


### PR DESCRIPTION
Overflow control on mobile devices.  It was found that CSS grid is the culprit.  Made the content a block on smaller devices and grid on small and up viewports.

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/35b9a8e1-3778-4c07-93bd-5259f38ffe0d)
