### PR TITLE
[frontend] cleanup keith oas section

### DIFF
--- a/frontend/public/locales/en/learn/case-studies/keith.json
+++ b/frontend/public/locales/en/learn/case-studies/keith.json
@@ -175,23 +175,11 @@
   },
 
   "oas": {
-    "heading": "Keith's OAS pension",
-    "p1": "Keith's income would not qualify him for the ",
-    "gis": {
-      "text": "Guaranteed Income Supplement",
-      "href": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/eligibility.html"
-    },
-    "p2": " (GIS), as he will continue to work up until age 70 with good salary. The GIS is for people with ",
-    "low-income": {
-      "text": "low income.",
-      "href": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/benefit-amount.html"
-    },
-    "p3": "Keith chooses to delay the Old Age Security (OAS) pension until age 70 to permanently increase it by 36%. This higher pension will help him transition better into retirement when he stops working at age 70.",
-    "p4": "To learn more about what to consider when choosing the age you want to start your OAS pension, ",
-    "fred-story": {
-      "text": "Fred decides when to start his public pensions",
-      "href": "/en/learn/case-studies/fred"
-    }
+    "p1": "Keith's income would not qualify him for the <a1>Guaranteed Income Supplement (GIS)</a1>, as he will continue to work up until age 70 with good salary. The GIS is for people with <a2>low income</a2>.",
+    "p2": "Keith chooses to delay the Old Age Security (OAS) pension until age 70 to permanently increase it by 36%. This higher pension will help him transition better into retirement when he stops working at age 70.",
+    "p3": "To learn more about what to consider when choosing the age you want to start your OAS pension, read <a3>Fred decides when to start his public pensions</a3>.",
+    "gis-link": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/eligibility.html",
+    "low-income-link": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/guaranteed-income-supplement/benefit-amount.html"
   },
 
   "conclusion": {

--- a/frontend/public/locales/fr/learn/case-studies/keith.json
+++ b/frontend/public/locales/fr/learn/case-studies/keith.json
@@ -175,23 +175,11 @@
   },
 
   "oas": {
-    "heading": "(FR) Keith's OAS pension",
-    "p1": "(FR) Keith's income would not qualify him for the ",
-    "gis": {
-      "text": "(FR) Guaranteed Income Supplement",
-      "href": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/admissibilite.html"
-    },
-    "p2": " (FR) (GIS), as he will continue to work up until age 70 with good salary. The GIS is for people with ",
-    "low-income": {
-      "text": "(FR) low income.",
-      "href": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/montant-prestation.html"
-    },
-    "p3": "(FR) Keith chooses to delay the Old Age Security (OAS) pension until age 70 to permanently increase it by 36%. This higher pension will help him transition better into retirement when he stops working at age 70.",
-    "p4": "(FR) To learn more about what to consider when choosing the age you want to start your OAS pension, ",
-    "fred-story": {
-      "text": "Fred décide quand prendre sa pension publique",
-      "href": "/fr/learn/case-studies/fred"
-    }
+    "p1": "(FR) Keith's income would not qualify him for the <a1>Guaranteed Income Supplement (GIS)</a1>, as he will continue to work up until age 70 with good salary. The GIS is for people with <a2>low income</a2>.",
+    "p2": "(FR) Keith chooses to delay the Old Age Security (OAS) pension until age 70 to permanently increase it by 36%. This higher pension will help him transition better into retirement when he stops working at age 70.",
+    "p3": "(FR) To learn more about what to consider when choosing the age you want to start your OAS pension, read <a3>Fred decides when to start his public pensions</a3>.",
+    "gis-link": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/admissibilite.html",
+    "low-income-link": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti/montant-prestation.html"
   },
 
   "conclusion": {

--- a/frontend/src/pages/learn/case-studies/keith.tsx
+++ b/frontend/src/pages/learn/case-studies/keith.tsx
@@ -272,15 +272,26 @@ const Keith: FC = () => {
           {t('oas.heading')}
         </h2>
         <p>
-          {t('oas.p1')}
-          <MuiLink href={t('oas.gis.text')} />
-          {t('oas.p2')}
-          <MuiLink href={t('oas.low-income.text')} />
+          <Trans
+            ns="learn/case-studies/keith"
+            i18nKey="oas.p1"
+            components={{
+              a1: <MuiLink href={t('oas.gis-link')} />,
+              a2: <MuiLink href={t('oas.low-income-link')} />,
+            }}
+          />
         </p>
-        <p>{t('oas.p3')}</p>
         <p>
-          {t('oas.p4')}
-          <MuiLink href={t('oas.fred-story.text')} />
+          <Trans ns="learn/case-studies/keith" i18nKey="oas.p2" />
+        </p>
+        <p>
+          <Trans
+            ns="learn/case-studies/keith"
+            i18nKey="oas.p3"
+            components={{
+              a3: <MuiLink component={Link} href="/learn/case-studies/fred" />,
+            }}
+          />
         </p>
 
         <h2 id="conclusion" className="h2">


### PR DESCRIPTION
Fix case study for Keith.  Upon doing a manual a11y scan with Axe, there were some issues with the links in the OAS section.  I've changed the structure/locales to resolve.

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/6af8cbf3-9985-40e0-b000-f1f3ee5c4c72)
