### PR TITLE
[frontend] attempt to get breakpoints closer to canada.ca

### DIFF
--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -14,6 +14,15 @@ const theme = createTheme({
       main: red.A400,
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 768,
+      lg: 992,
+      xl: 1200,
+    },
+  },
   typography: {
     fontFamily: '"Noto Sans", sans-serif',
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -98,14 +98,14 @@ module.exports = {
       sm: '600px',
       // => @media (min-width: 600px) { ... }
 
-      md: '900px',
-      // => @media (min-width: 900px) { ... }
+      md: '768px',
+      // => @media (min-width: 768px) { ... }
 
-      lg: '1200px',
+      lg: '992px',
+      // => @media (min-width: 992px) { ... }
+
+      xl: '1200px',
       // => @media (min-width: 1200px) { ... }
-
-      xl: '1536px',
-      // => @media (min-width: 1536px) { ... }
     },
   },
   corePlugins: {


### PR DESCRIPTION
Not sure if this is the approach we should take, so here's a quick PR to adjust viewport breakpoints to align more with canada.ca.

I'm using [this as a reference](https://wet-boew.github.io/wet-boew-styleguide/design/grids-en.html)

From slack:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/7fb6fdce-7c42-43d4-b58d-be9529fa77de)


