### PR TITLE
[Frontend] add Breadcrumb structured data

### DIFF
--- a/frontend/src/components/ApplicationNameBar.tsx
+++ b/frontend/src/components/ApplicationNameBar.tsx
@@ -5,6 +5,7 @@ import { Button, Link as MuiLink } from '@mui/material'
 import Link from 'next/link'
 
 import { Breadcrumb, BreadcrumbItem } from './Breadcrumb'
+import BreadcrumbStructuredData from './BreadcrumbStructuredData'
 
 export interface ApplicationNameBarProps {
   breadcrumbItems?: BreadcrumbItem[]
@@ -40,6 +41,7 @@ const ApplicationNameBar: FC<ApplicationNameBarProps> = ({
               </MuiLink>
             </div>
             <Breadcrumb items={breadcrumbItems} />
+            <BreadcrumbStructuredData items={breadcrumbItems} />
           </div>
           <div>
             {!hideChecklist && (

--- a/frontend/src/components/BreadcrumbStructuredData.tsx
+++ b/frontend/src/components/BreadcrumbStructuredData.tsx
@@ -1,0 +1,51 @@
+import { FC } from 'react'
+
+import { useTranslation } from 'next-i18next'
+import getConfig from 'next/config'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+
+import { BreadcrumbProps } from './Breadcrumb'
+
+interface ListItem {
+  '@type': 'ListItem'
+  'position': number
+  'name': string
+  'item'?: string
+}
+
+const BreadcrumbStructuredData: FC<BreadcrumbProps> = ({ items }) => {
+  const { locale } = useRouter()
+  const { t } = useTranslation('common')
+  const config = getConfig()
+  const appBaseUri = config?.publicRuntimeConfig?.appBaseUri
+
+  const itemListElement: Array<ListItem> = [
+    {
+      '@type': 'ListItem',
+      'position': 1,
+      'name': t('goc-site'),
+      'item': t('header.goc-link'),
+    },
+    ...(items?.map<ListItem>(({ link, text }, index) => ({
+      '@type': 'ListItem',
+      'position': index + 2,
+      'name': text,
+      'item': `${appBaseUri}/${locale}${link}`,
+    })) ?? []),
+  ]
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': itemListElement,
+  }
+
+  return (
+    <Head>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+    </Head>
+  )
+}
+
+export default BreadcrumbStructuredData


### PR DESCRIPTION
## [AB#117](https://dev.azure.com/JourneyLab/e5439067-4cca-4d9d-9c04-19430d3be3db/_workitems/edit/117)
### Description

List of proposed changes:

- add Breadcrumb structured data

### What to test for/How to test

Set the following variable in `.env.local`:

```yaml
# Base URI for the Application
NEXT_PUBLIC_APP_BASE_URI=http://localhost:3000
```

### Additional Notes

https://developers.google.com/search/docs/appearance/structured-data/breadcrumb