### PR TITLE
[frontend] a11y modify headings

### DIFF
--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -81,8 +81,6 @@ const Home: FC = () => {
         additionalMetaTags={[getDCTermsTitle(en('header'), fr('header'))]}
       />
       <Layout contained={false}>
-        <h1 className="sr-only">{t('header')}</h1>
-
         <Container className="mb-8 md:mb-12">
           <HeroBanner
             imageProps={{
@@ -93,9 +91,9 @@ const Home: FC = () => {
               width: 640,
             }}
           >
-            <h2 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
+            <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
               {t('banner.title')}
-            </h2>
+            </h1>
             <p className="m-0">{t('banner.text')}</p>
           </HeroBanner>
         </Container>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -173,7 +173,6 @@ const Learn: FC = () => {
           },
         ]}
       >
-        <h1 className="sr-only">{t('header')}</h1>
         <HeroBanner
           imageProps={{
             alt: '',
@@ -183,9 +182,9 @@ const Learn: FC = () => {
             width: 640,
           }}
         >
-          <h2 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
+          <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
             {t('banner.title')}
-          </h2>
+          </h1>
           <p>{t('banner.text')}</p>
           <Button component={Link} id="quiz-dialog-link" size="large" href="/quiz">
             {t('banner.quiz')}


### PR DESCRIPTION
## [ADO-453](https://dev.azure.com/JourneyLab/SeniorsJourney/_sprints/taskboard/DTS/SeniorsJourney/DTS/DTS%20-%20Sprint%207?workitem=453)

### Description

```Issue: Heading structure must be meaningful within the pages. The <h1> is currently only available for "Screen reader only" <h1 class="sr-only">Home</h1> and should be available to everyone. Restructuring the headings within the site would be needed. You guys are using changes in text presentation to make this heading look larger to convey that it is the main page heading but they are not conveying that info in the code to AT users.    Descriptive headings are especially helpful for users who have disabilities that make reading slow and for people with limited short-term memory. These people benefit when section titles make it possible to predict what each section contains.    Where/how to reproduce: When you check the source code of the page  <h1 class="sr-only">Home</h1>. The first heading that you see is "Retirement Hub" and it's a H2.    Solution:  You can go ahead and remove <h1 class="sr-only">Home</h1>.  Please have the <h1> visible to everyone  and we think that the <h1> should be "Learn and plan for your retirement".    Please see: https://www.w3.org/WAI/WCAG21/Techniques/failures/F2```


List of proposed changes:

- remove screen-reader only headers (assistive technology will use the headings, so it's redundant to have an SR only headings)
- change what should be h2 to h1
