### PR TITLE
[frontend] a11y tabs on home page

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -95,6 +95,7 @@
       "heading": "Take control of your public pensions with the My Service Canada Account (MSCA)",
       "title": "Manage"
     },
+    "more": "More",
     "plan": {
       "button": {
         "text": "Take the quiz"

--- a/frontend/public/locales/fr/home.json
+++ b/frontend/public/locales/fr/home.json
@@ -95,6 +95,7 @@
       "heading": "Prenez le contrôle de vos prestations de vieillesse fédérales grâce à Mon dossier Service Canada (MDSC)",
       "title": "Gérer"
     },
+    "more": "Plus",
     "plan": {
       "button": {
         "text": "Répondez au questionnaire"

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,9 +1,11 @@
 import React, { FC, useMemo, useState } from 'react'
 
+import { ExpandLess, ExpandMore } from '@mui/icons-material'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
 import {
   Button,
+  Collapse,
   Divider,
   List,
   ListItem,
@@ -46,9 +48,10 @@ const Home: FC = () => {
   const appBaseUri = config?.publicRuntimeConfig?.appBaseUri
 
   const theme = useTheme()
-  const mobile = useMediaQuery(theme.breakpoints.down('md'))
+  const extraSmall = useMediaQuery(theme.breakpoints.down('sm'))
 
   const [value, setValue] = useState('learn')
+  const [open, setOpen] = useState(false)
 
   const handleChange = (event: React.SyntheticEvent, newValue: string) => {
     setValue(newValue)
@@ -103,17 +106,54 @@ const Home: FC = () => {
         <section>
           <TabContext value={value}>
             <Paper elevation={4} square className="relative">
-              <TabList
-                variant={mobile ? 'scrollable' : 'standard'}
-                onChange={handleChange}
-                scrollButtons="auto"
-                centered={!mobile}
-              >
-                <Tab value="learn" label={t('tabs.learn.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                <Tab value="plan" label={t('tabs.plan.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                <Tab value="apply" label={t('tabs.apply.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                <Tab value="manage" label={t('tabs.manage.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-              </TabList>
+              {!extraSmall && (
+                <TabList onChange={handleChange} scrollButtons="auto" centered>
+                  <Tab value="learn" label={t('tabs.learn.title')} className="px-10 pt-4 text-lg md:text-2xl" />
+                  <Tab value="plan" label={t('tabs.plan.title')} className="px-10 pt-4 text-lg md:text-2xl" />,
+                  <Tab value="apply" label={t('tabs.apply.title')} className="px-10 pt-4 text-lg md:text-2xl" />,
+                  <Tab value="manage" label={t('tabs.manage.title')} className="px-10 pt-4 text-lg md:text-2xl" />,
+                </TabList>
+              )}
+              {extraSmall && (
+                <div className="px-4 py-2">
+                  <div className="flex gap-1">
+                    <Button
+                      variant="outlined"
+                      onClick={() => setValue('learn')}
+                      className="grow underline underline-offset-4"
+                    >
+                      {t('tabs.learn.title')}
+                    </Button>
+                    <Button
+                      onClick={() => setOpen(!open)}
+                      endIcon={open ? <ExpandLess /> : <ExpandMore />}
+                      className="grow"
+                    >
+                      {t('tabs.more')}
+                    </Button>
+                  </div>
+                  <Collapse in={open}>
+                    <TabList
+                      variant="fullWidth"
+                      orientation="vertical"
+                      onChange={handleChange}
+                      className="px-10 pt-4 text-lg md:text-2xl"
+                      TabIndicatorProps={{
+                        style: {
+                          display: 'none',
+                        },
+                      }}
+                    >
+                      <Tab value="learn" label={t('tabs.learn.title')} />
+                      <Tab value="plan" label={t('tabs.plan.title')} />
+                      ,
+                      <Tab value="apply" label={t('tabs.apply.title')} />
+                      ,
+                      <Tab value="manage" label={t('tabs.manage.title')} />,
+                    </TabList>
+                  </Collapse>
+                </div>
+              )}
             </Paper>
 
             <div className="bg-gray-surface">


### PR DESCRIPTION
## [ADO-455](https://dev.azure.com/JourneyLab/SeniorsJourney/_sprints/taskboard/DTS/SeniorsJourney/DTS/DTS%20-%20Sprint%207?workitem=455)

### Description

The tabs on the home page were flagged during an accessibility audit because they don't technically conform to the reflow WCAG success criterion even though they have a horizontal scroll.  The advice of the IT Accessibility Office was to either make the tabs stackable, or have a feature that can toggle tabs using a "more button".

List of proposed changes:
- modify code to only display accessible tab picker on extra small (<600px) viewports

### Additional Notes

I couldn't figure out a way to do this cleanly with MUI.  The premise in this PR is that the "more button" will expand/collapse the tabs that you select from.  Unfortunately I couldn't figure out how to have 1 tab separate and the others grouped in a collapseable sections without MUI throwing an error about the other tab missing from the available options.  Thus, there is a duplicate tab button for the Learn tab under the Tablist and as a separate button.   Notice how I've styled the buttons as buttons so that it's evident they are interactive and modify the page in some way.  This deviates from the mockup, but I think it aligns with what users would expect.  