### PR TITLE
AB#454 A11Y Contrast Issue

### DIFF
--- a/frontend/public/locales/fr/learn/planning-to-save-for-retirement.json
+++ b/frontend/public/locales/fr/learn/planning-to-save-for-retirement.json
@@ -3,10 +3,10 @@
     "learn": "Apprendre"
   },
   "changes-with-age": {
-    "disclaimer": "(FR) <strong>Disclaimer:</strong> This website is meant to give you tips on when to take your public pensions. We do not provide financial advice. Once you have all the information you need, we encourage you to seek help from a financial advisor.",
-    "heading": "(FR) How your financial needs may change with age",
-    "p1": "(FR) While you're budgeting for retirement, remember that your budget won't always be the same. In early retirement, you may want extra money to travel, or pursue hobbies that you didn't have the time for during your working years. As you get older, you may find your spending habits shift. You may spend less money on shopping or going out, and more on healthcare, medications, and home care.",
-    "p2": "(FR) As you age, you may consider long-term care costs such as assisted living or nursing home care. These choices cost a lot, and you should consider having a plan. You could have savings ahead of time or buy insurance to cover any costs you didn't plan for. These are some options that could work for you, depending on your situation."
+    "disclaimer": "<strong>Avertissement\u00a0:</strong> ce site Web vise à vous donner des conseils sur le bon moment pour toucher vos pensions publiques. Nous ne fournissons pas de conseils financiers. Une fois que vous avez toute l'information dont vous avez besoin, nous vous encourageons à demander l'aide d'un conseiller financier.",
+    "heading": "Comment vos besoins financiers peuvent-ils évoluer avec l'âge",
+    "p1": "Lorsque vous planifiez votre retraite, souvenez-vous que votre budget ne sera pas toujours le même. Si vous optez pour une retraite anticipée, vous aurez peut-être besoin de plus d'argent pour voyager ou faire des activités auxquelles vous n'aviez pas de temps à consacrer pendant vos années de travail. En vieillissant, vos habitudes de dépenses pourraient changer. Vous pourriez dépenser moins d'argent pour faire vos courses ou sortir, et dépenser davantage en soins de santé, en médicaments et en soins à domicile.",
+    "p2": "En vieillissant, vous pourriez aussi devoir payer des frais pour des soins de longue durée, comme des services d'assistance ou des soins dans un foyer de soins infirmiers. Ces choix coûtent cher et vous devriez envisager d'avoir un plan. Vous pourriez économiser à l'avance ou souscrire une assurance pour couvrir les coûts que vous n'aviez pas prévus. Voici quelques options qui pourraient vous convenir, selon votre situation."
   },
   "header": "Planifiez pour épargner en vue de la retraite",
   "how-much": {
@@ -14,36 +14,36 @@
     "a2": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/supplement-revenu-garanti.html",
     "a3": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/calculatrice-revenu-retraite.html",
     "a4": "https://itools-ioutils.fcac-acfc.gc.ca/BP-PB/planificateur-budgetaire",
-    "heading": "(FR) How much you could need in retirement",
-    "p1": "(FR) When you retire, you may need less money per month than what you need now. You might not need to drive as much, have less work-related spending, reduced child-related and housing costs. With more free time, you might want to travel more, or do some renovations in your house. Everyone's retirement looks different, so it's important to think about what you want and plan for it. Think about things like your health, where you want to live, and how much money you'll have from pensions and savings. Generally, you won't need as much as you do now to keep your way of living. Many financial planners say that having 60 to 70% of your current income in retirement will allow you to maintain your lifestyle in retirement. But, this rule of thumb doesn't work for everyone. If you have <a1>low income</a1>, you might need the same amount of money when you retire as you do now to cover all your basic needs. The <a2>Guaranteed Income Supplement (GIS)</a2> is an important source of income for low-income retirees. People with higher income may only need have 50 to 60% of their current income in retirement. Think about your personal situation when planning for retirement, so you can save the right amount.",
-    "p2": "(FR) You can model your future retirement income from different sources using the <a3>Canadian Retirement Income Calculator</a3>.",
-    "p3": "(FR) Create a customized budget using the <a4>FCAC Budget planner</a4>."
+    "heading": "De combien d'argent aurez-vous besoin à la retrait",
+    "p1": "À votre retraite, vos besoins monétaires mensuels seront probablement moins importants qu'aujourd'hui. Vous utiliserez peut-être moins votre voiture et vos dépenses liées au travail, les coûts liés aux enfants et vos frais de logement seront moindres. Comme vous aurez plus de temps libre, vous voudrez peut-être voyager davantage ou faire des rénovations dans votre maison. Les projets de retraite de chacun sont différents; il est donc important de réfléchir à ce que vous voulez faire et de planifier en conséquence. Vous devez tenir compte des facteurs comme votre état de santé, l'endroit où vous voulez vivre, l'ampleur de vos économies et le montant des pensions que vous toucherez. En général, vous n'aurez pas besoin d'autant d'argent pour conserver votre mode de vie. De nombreux planificateurs financiers sont d'avis qu'une fois à la retraite, il vous suffira de toucher de 60 à 70\u00a0% de votre revenu actuel pour maintenir votre mode de vie. Toutefois, cette règle ne s'applique pas pour tout le monde. Si vous avez un <a1>faible revenu</a1>, vous pourriez avoir besoin du même montant d'argent à votre retraite qu'à l'heure actuelle pour subvenir à tous vos besoins de base. <a2>Le Supplément de revenu garanti (SRG)</a2> est une importante source de revenus pour les retraités à faible revenu. Les personnes dont le revenu est plus élevé n'auront peut-être besoin que de 50 à 60\u00a0% de leur revenu actuel à la retraite. Vous devez réfléchir à votre situation personnelle lorsque vous planifiez votre retraite afin de pouvoir économiser le bon montant.",
+    "p2": "Vous pouvez modéliser votre revenu de retraite futur provenant de différentes sources à l'aide de la <a3>Calculatrice du revenu de retraite canadienne</a3>.",
+    "p3": "Apprenez-en davantage sur le <a4>Planificateur budgétaire de l'ACFC</a4>."
   },
   "key-takeaways": {
-    "heading": "(FR) Key takeaways",
-    "li1": "(FR) When planning for retirement, consider how much money you'll need based on your personal situation.",
-    "li2": "(FR) Your health, your income, and what you want your retirement to look like will change your budget.",
-    "li3": "(FR) Your financial needs and circumstances may change with age.",
-    "li4": "(FR) It's important to review your financial plan to change as needed."
+    "heading": "Points à retenir",
+    "li1": "Lorsque vous planifiez votre retraite, tenez compte du montant dont vous aurez besoin en fonction de votre situation personnelle.",
+    "li2": "Votre santé, votre revenu et ce que vous voulez faire à votre retraite auront une incidence sur votre budget.",
+    "li3": "Vos besoins financiers et votre situation peuvent changer avec l'âge.",
+    "li4": "Il est important de revoir votre plan financier pour le modifier au besoin."
   },
   "learn-more": {
     "budget-planner": {
-      "description": "(FR) The Budget Planner helps you create a customized budget in 3 simple steps.",
-      "header": "(FR) Budget Planner Tool - Financial Consumer Agency of Canada",
+      "description": "Le Planificateur budgétaire vous aide à créer un budget personnalisé en trois étapes simples.",
+      "header": "Planificateur budgétaire - Agence de la consommation en matière financière du Canada",
       "href": "https://itools-ioutils.fcac-acfc.gc.ca/BP-PB/planificateur-budgetaire"
     },
     "going-from-work-to-retirement": {
-      "description": "(FR) You can choose different ways to go from work to retirement. Retiring from work and starting your public pensions are two different things.",
+      "description": "Vous pouvez choisir différentes manière d' effectuer une transition du monde du travail a celui de la retraite. Prendre sa retraite du monde du travail et commencer a recevoir ses pensions publiques sont deux choses différentes.",
       "header": "Transition du monde du travail à la retraite"
     },
     "heading": "En savoir plus",
     "main-sources-of-retirment-income": {
-      "description": "(FR) See the different types of retirement income you could have. Look at your current income sources and find potential gaps.",
-      "header": "Principales sources de revenus de retraite"
+      "description": "Renseignez-vous sur les différentes sources de revenus de retraite dont vous pourriez bénéficier. Examiner vos sources de revenus et identifier les écarts potentiel.",
+      "header": "Principales sources de revenu de retraite"
     },
     "saving-for-retirement": {
-      "description": "(FR) When, why and how to start saving for your retirement and tips to help balance your financial priorities.",
-      "header": "(FR) Saving for retirement",
+      "description": "Quand, pourquoi et comment commencer à épargner en vue de votre retraite et conseils pour vous aider à équilibrer vos priorités financières.",
+      "header": "Épargne-retraite",
       "href": "https://www.canada.ca/fr/agence-consommation-matiere-financiere/services/planification-retraite/economiser-pour-retraite.html"
     }
   },
@@ -51,7 +51,7 @@
     "description": "Découvrez comment vos besoins en ce qui concerne vos revenus vont changer. Vos besoins financiers et vos préoccupations vont aussi changer."
   },
   "overview": {
-    "heading": "(FR) Overview",
-    "p": "(FR) Planning for retirement may feel stressful, but it's needed to make sure you've got a comfortable and secure future that aligns with your goals. With so many choices, it can be hard to know where to start to get the most out of your savings. The sections below are meant to inform you as you go through this important process."
+    "heading": "Aperçu",
+    "p": "La planification de la retraite peut vous sembler stressante, mais cela est nécessaire pour vous assurer d'avoir un avenir à l'aise et sûr qui correspond à vos objectifs. Avec autant de choix, il peut être difficile de savoir par où commencer pour tirer le meilleur parti de vos économies. Les sections ci-dessous visent à vous informer des étapes à suivre tout au long de cet important processus."
   }
 }

--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -30,6 +30,9 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
       },
       ".MuiAccordion-root.Mui-expanded":{
         margin: "0"
+      },
+      ".MuiAccordionSummary-root:focus":{
+        backgroundColor:"#00363C"
       }
     }}>
       <AccordionSummary
@@ -48,6 +51,9 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
             boxShadow: '0',
             ".MuiAccordionSummary-root.Mui-expanded": {
               borderTop: "1px solid rgba(0, 0, 0, 0.12)",
+            },
+            ".MuiAccordionSummary-root:focus":{
+              backgroundColor:"transparent"
             }
           }}
         >

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -36,6 +36,33 @@ const theme = createTheme({
         root: {
           fontFamily: 'Lato, sans-serif',
           textTransform: 'none',
+          "&.Mui-focusVisible":{
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          }
+        }
+      },
+    },
+    MuiButtonBase:{
+      defaultProps:{
+        disableRipple: true,
+      },
+      styleOverrides: {
+        root: {
+          "&.Mui-focusVisible":{
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          }
+        }
+      }
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          "&:focus-within": {
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          },
+          "& .MuiCardActionArea-focusHighlight": {
+            backgroundColor: 'transparent',
+          },
         },
       },
     },
@@ -43,6 +70,15 @@ const theme = createTheme({
       defaultProps: {
         color: 'secondary',
       },
+    },
+    MuiListItemButton:{
+      styleOverrides:{
+        root:{
+          "&:focus-within": {
+            backgroundColor: 'transparent',
+          },
+        }
+      }
     },
     MuiTab: {
       styleOverrides: {


### PR DESCRIPTION
## [ADO-454](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/454)

### Description

List of proposed changes:

- Accessibility caught an issue with our focus styling across the site having insufficient contrast, since a 3:1 contrast ratio made the text difficult to read on most elements I've swapped everything out with a focus outline instead.
- Disabled Ripple Effects, all button elements now have box-shadow outline on focus

### What to test for/How to test
- Tab through site elements to see new outlines, this should resolve the a11y issue since the new color has a 9:1 ratio

### Additional Notes
- Open for suggestions on how this could be done stylistically, just wanted to keep it consistent throughout