### PR TITLE
AB#454 A11y Contrast Issue

### DIFF
--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -30,6 +30,9 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
       },
       ".MuiAccordion-root.Mui-expanded":{
         margin: "0"
+      },
+      ".MuiAccordionSummary-root:focus":{
+        backgroundColor:"#00363C"
       }
     }}>
       <AccordionSummary
@@ -48,6 +51,9 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
             boxShadow: '0',
             ".MuiAccordionSummary-root.Mui-expanded": {
               borderTop: "1px solid rgba(0, 0, 0, 0.12)",
+            },
+            ".MuiAccordionSummary-root:focus":{
+              backgroundColor:"transparent"
             }
           }}
         >

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -36,6 +36,33 @@ const theme = createTheme({
         root: {
           fontFamily: 'Lato, sans-serif',
           textTransform: 'none',
+          "&.Mui-focusVisible":{
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          }
+        }
+      },
+    },
+    MuiButtonBase:{
+      defaultProps:{
+        disableRipple: true,
+      },
+      styleOverrides: {
+        root: {
+          "&.Mui-focusVisible":{
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          }
+        }
+      }
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          "&:focus-within": {
+            boxShadow: '0 0 0 2px #ffffff, 0 0 3px 5px #004f56',
+          },
+          "& .MuiCardActionArea-focusHighlight": {
+            backgroundColor: 'transparent',
+          },
         },
       },
     },
@@ -43,6 +70,15 @@ const theme = createTheme({
       defaultProps: {
         color: 'secondary',
       },
+    },
+    MuiListItemButton:{
+      styleOverrides:{
+        root:{
+          "&:focus-within": {
+            backgroundColor: 'transparent',
+          },
+        }
+      }
     },
     MuiTab: {
       styleOverrides: {


### PR DESCRIPTION
## [ADO-454](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/454)

### Description

List of proposed changes:

- Accessibility caught an issue with our focus styling across the site having insufficient contrast, since a 3:1 contrast ratio made the text difficult to read on most elements I've swapped everything out with a focus outline instead.
- Disabled Ripple Effects, all button elements now have box-shadow outline on focus

### What to test for/How to test
- Tab through site elements to see new outlines, this should resolve the a11y issue since the new color has a 9:1 ratio
- 
### Additional Notes
- Re-created PR to fix merge issue