### PR TITLE
[frontend] checklist accordions persistent state

### DIFF
--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -7,58 +7,81 @@ import { TaskDto } from '../lib/types'
 import TaskCard from './TaskCard'
 
 interface NestedAccordionProps {
+  expanded: boolean
+  expandedTasks: ReadonlyArray<number>
+  id: number
   linksHeader: string
+  onTaskAccordionChange: (id: number, expanded: boolean) => void
+  onTaskGroupAccordionChange: (id: number, expanded: boolean) => void
   sectionTitle: string
   subSectionTitle: string
   tasks: ReadonlyArray<TaskDto>
 }
 
 const NestedAccordion: React.FC<NestedAccordionProps> = ({
+  expanded,
+  expandedTasks,
+  id,
   linksHeader,
+  onTaskAccordionChange,
+  onTaskGroupAccordionChange,
   sectionTitle,
   subSectionTitle,
   tasks = [],
 }) => {
   return (
-    <Accordion className="mb-4" disableGutters
-    sx={{
-      "@media print": {
-        ".MuiCollapse-root": {
-          height: "auto !important",
-          visibility: "visible !important"
-        }
-      },
-      ".MuiAccordion-root.Mui-expanded":{
-        margin: "0"
-      },
-      ".MuiAccordionSummary-root:focus":{
-        backgroundColor:"#00363C"
-      }
-    }}>
+    <Accordion
+      className="mb-4"
+      disableGutters
+      expanded={expanded}
+      onChange={(_, exp) => {
+        onTaskGroupAccordionChange(id, exp)
+      }}
+      sx={{
+        '@media print': {
+          '.MuiCollapse-root': {
+            height: 'auto !important',
+            visibility: 'visible !important',
+          },
+        },
+        '.MuiAccordion-root.Mui-expanded': {
+          margin: '0',
+        },
+        '.MuiAccordionSummary-root:focus': {
+          backgroundColor: '#00363C',
+        },
+      }}
+    >
       <AccordionSummary
         className="bg-[#00363C] text-white"
         disabled={tasks.length === 0}
         expandIcon={<ExpandMoreIcon className="text-white" />}
       >
         <div>
-          <div className="mb-2 font-display font-bold text-xl">{sectionTitle}</div>
+          <div className="mb-2 font-display text-xl font-bold">{sectionTitle}</div>
           <div className="text-sm opacity-70">{subSectionTitle}</div>
         </div>
       </AccordionSummary>
       {tasks.map((task) => (
-        <Accordion key={task.id} disableGutters
+        <Accordion
+          key={task.id}
+          disableGutters
+          expanded={expandedTasks.includes(task.id)}
+          onChange={(_, expanded) => {
+            onTaskAccordionChange(task.id, expanded)
+          }}
           sx={{
-            boxShadow: '0',
-            ".MuiAccordionSummary-root.Mui-expanded": {
-              borderTop: "1px solid rgba(0, 0, 0, 0.12)",
+            'boxShadow': '0',
+            '.MuiAccordionSummary-root.Mui-expanded': {
+              borderTop: '1px solid rgba(0, 0, 0, 0.12)',
             },
-            ".MuiAccordionSummary-root:focus":{
-              backgroundColor:"transparent"
-            }
+            '.MuiAccordionSummary-root:focus': {
+              backgroundColor: 'transparent',
+            },
           }}
         >
-          <AccordionSummary className="font-display font-medium py-2 text-lg" expandIcon={<ExpandMoreIcon />}>
-          <Checkbox className="-mt-2.5 hidden print:inline"/>
+          <AccordionSummary className="py-2 font-display text-lg font-medium" expandIcon={<ExpandMoreIcon />}>
+            <Checkbox className="-mt-2.5 hidden print:inline" />
             {task.title}
           </AccordionSummary>
           <AccordionDetails>


### PR DESCRIPTION
### Description

Set the checklist accordions expanded state persistant on change using url query string. That way if a user navigate away by with any links in task and go back then the user should see the same page state as before.

List of proposed changes:

- checklist accordions persistent state using query string