### PR TITLE
[frontend] Add unsafe-inline CSP for AA

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -21,4 +21,3 @@ OTEL_TRACES_ENDPOINT=https://example.com/e/00000000-0000-0000-0000-000000000000/
 # Content-Security-Policy response header settings
 # These settings have default values within the application, so should only be changed if the Adobe Analytics scripts change
 ADOBE_ANALYTICS_CSP_DOMAINS=["*.demdex.net", "assets.adobedtm.com", "cm.everesttech.net", "code.jquery.com"]
-ADOBE_ANALYTICS_CSP_SCRIPT_HASHES=["'sha256-eUTan7s7Let/AtTx7e/BFrXBJ1hNp+oNNppAFt05OMc='", "'sha256-ijXSZE47lIAA0cp6SwVwWQroK1Mbcv6gKq8PugakSdI='", "'sha256-WR7dYY/Sv6nA60KEEdlxilApWnN1lTS8373DIVAL42U='"]


### PR DESCRIPTION
## [ADO-256](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/256)

### Description

Add CSP `unsafe-inline` script directives when Adobe Analytics is enabled.