### PR TITLE
QC Landing and Learning Pages

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -106,7 +106,7 @@
         "oas-eligibility-estimator": {
           "description": "Find out how much money you may get from the Old Age Security program and its benefits.",
           "title": "Old Age Security eligibility estimator",
-          "url": "https://alpha.service.canada.ca/en/projects/oas-benefits-estimator"
+          "url": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security/payments.html"
         },
         "retirement-income-calculator": {
           "description": "The Canadian Retirement Income Calculator will provide you with retirement income information. This includes the Old Age Security (OAS) pension and Canada Pension Plan (CPP) retirement benefits.",

--- a/frontend/public/locales/en/learn.json
+++ b/frontend/public/locales/en/learn.json
@@ -54,7 +54,7 @@
           "title": "Fred decides when to start his public pensions"
         },
         "keith": {
-          "body": "Keith chooses between delaying his public pensions or taking Post-retirement benefits while working.",
+          "body": "Keith chooses between delaying his public pensions or taking post-retirement benefits while working.",
           "title": "Keith collects his public pensions while working"
         }
       },

--- a/frontend/public/locales/en/learn.json
+++ b/frontend/public/locales/en/learn.json
@@ -2,7 +2,7 @@
   "banner": {
     "quiz": "Take the quiz now!",
     "text": "Receive a personalized checklist to guide you through retirement.",
-    "title": "Not sure where to begin? Take the quiz!"
+    "title": "Not sure where to start? Take our quiz!"
   },
   "header": "Explore Retirement",
   "meta": {
@@ -43,7 +43,7 @@
       "title": "Making retirement decisions"
     },
     "stories": {
-      "body": "Not sure when to retire? Read the stories that people shared with us. Learn about the different choices and compare them to your personal situation.",
+      "body": "Not sure when to retire? Learn about the different choices people make about their public pensions and how it impacts their lives. These stories give valuable lessons and inspiration for people looking to plan their own retirement.",
       "cards": {
         "bonnie": {
           "body": "Bonnie will need less savings to retire comfortably if she delays her OAS pension and her CPP retirement pension.",
@@ -54,7 +54,7 @@
           "title": "Fred decides when to start his public pensions"
         },
         "keith": {
-          "body": "Keith chooses between delaying his public pensions or taking Post-Retirement Benefits while working.",
+          "body": "Keith chooses between delaying his public pensions or taking Post-retirement benefits while working.",
           "title": "Keith collects his public pensions while working"
         }
       },

--- a/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
+++ b/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
@@ -140,7 +140,7 @@
       "description": "You may have other sources like a workplace pension or personal savings.",
       "header": "The public pensions are meant to be a part of your retirement income plan."
     },
-    "header": "Key Takeaways",
+    "header": "Key takeaways",
     "not-need-to-stop-working": {
       "description": "You don't have to stop working to collect your public pensions.",
       "header": "Retiring from your work and starting to collect your public pensions are two different things."

--- a/frontend/public/locales/fr/home.json
+++ b/frontend/public/locales/fr/home.json
@@ -58,25 +58,25 @@
     "learn": {
       "button-text": "Renseignez-vous sur la retraite",
       "description": {
-        "options-and-tips": "Il y a de nombreux facteurs à prendre en compte avant de prendre sa retraite.",
-        "stories": "Découvrez les bases des prestations de vieillesse au Canada et les moyens de gérer votre argent à la retraite."
+        "options-and-tips": "Renseignez-vous sur vos options de revenu à la retraite et des conseils pour les pensions de la SV/RPC.",
+        "stories": "Lisez les histoires de retraités et leur choix de pension publique."
       },
       "heading": "Tirez le maximum de vos régimes de pension au Canada",
       "links": {
         "case-study-bonnie": {
-          "description": "Si Bonnie décide d'attendre avant de commencer à recevoir sa pension de la SV et du RPC, elle aura besoin de moins d'épargnes.",
-          "title": "Bonnie décide d'attendre afin de réduire les épargnes dont elle a besoin"
+          "description": "Bonnie reporte le versement de ses pension publiques et aura besoin de moins d'épargnes pour prendre sa retraite.",
+          "title": "Bonnie reporte sa pension pour réduire les épargnes dont elle a besoin"
         },
         "rules-of-thumb": {
-          "description": "Consultez ces conseils pour vous aider à décider quand prendre vos pensions de la SV et du RPC. Choisissez ce qui vous convient.",
-          "title": "Règles générales sur les régimes de pensions publics"
+          "description": "Jetez un coup d'œil sur ces conseils pour vous aider a prendre la décision de quand commencer à recevoir vos pensions. Faite le choix adapter à votre situation.",
+          "title": "Règles générales concernant les pensions publiques"
         },
         "when-to-collect": {
-          "description": "La flexibilité des pensions de la SV et du RPC vous offre des choix pour votre retraite. Apprenez quels sont les aspects à prendre en considération et comment en venir à une décision.",
-          "title": "Choisir quand commencer à recevoir vos pensions publiques"
+          "description": "La souplesse des pensions publiques vous offre des options de retraite. Découvrez quoi choisir et les éléments à considérer.",
+          "title": "Décider quand recevoir sa pension publique"
         }
       },
-      "linksTitle": "Principaux liens pour l'apprentissage en ce qui concerne la retraite",
+      "linksTitle": "Principaux liens d'apprentissage",
       "title": "Apprendre"
     },
     "manage": {
@@ -106,7 +106,7 @@
         "oas-eligibility-estimator": {
           "description": "Découvrez les montants que vous pourriez recevoir dans le cadre du programme de la Sécurité de la vieillesse et ses prestations.",
           "title": "Estimateur de prestations de la Sécurité de la vieillesse",
-          "url": "https://alpha.service.canada.ca/fr/projets/estimateur-prestations-sv"
+          "url": "https://www.canada.ca/fr/services/prestations/pensionspubliques/rpc/securite-vieillesse/paiements.html"
         },
         "retirement-income-calculator": {
           "description": "Obtenez une estimation de votre revenu de retraite. Cette estimation tient compte de vos prestations de vieillesse fédérales et de votre revenu de retraite d'un régime privé.",

--- a/frontend/public/locales/fr/learn.json
+++ b/frontend/public/locales/fr/learn.json
@@ -43,7 +43,7 @@
       "title": "Prendre des décisions concernant la retraite"
     },
     "stories": {
-      "body": "Vous ne savez pas quand prendre votre retraite. Lisez les histoires dont certaines personnes nous ont fait part. Découvrez les différents choix et comparez-les à votre situation personnelle.",
+      "body": "Vous ne savez pas quand prendre votre retraite? Apprenez-en davantage sur les différents choix que les gens font au sujet de leurs pensions publiques et l'effet sur leur vie quotidienne. Ces histoires donnent des leçons valorisantes et inspirantes pour les gens qui cherchent à planifier leur propre retraite.",
       "cards": {
         "bonnie": {
           "body": "Bonnie reporte le versement de ses pension publiques et aura besoin de moins d'épargnes pour prendre sa retraite.",

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -158,7 +158,7 @@ const Home: FC = () => {
               <Container>
                 <TabPanel value="learn" className="px-0 py-8">
                   <div className="flex flex-col gap-6 md:flex-row">
-                    <Paper className="p-8 md:w-2/5 md:grow">
+                    <Paper className="p-8 md:w-2/6 md:grow">
                       <h2 className="mb-8 font-display text-2xl font-medium text-primary-700 md:text-4xl">
                         {t('tabs.learn.heading')}
                       </h2>
@@ -172,8 +172,8 @@ const Home: FC = () => {
                         </Button>
                       </div>
                     </Paper>
-                    <Paper className="p-8 md:w-3/5">
-                      <h3 className="mb-8 font-display text-xl font-light md:mb-11 md:text-3xl">
+                    <Paper className="p-8 md:w-4/6">
+                      <h3 className="mb-8 font-display text-xl font-light md:mb-8 md:text-3xl">
                         {t('tabs.learn.linksTitle')}
                       </h3>
                       <List disablePadding>
@@ -182,11 +182,11 @@ const Home: FC = () => {
                             <ListItemText
                               primary={t('tabs.learn.links.when-to-collect.title')}
                               primaryTypographyProps={{
-                                className: 'font-display font-medium',
+                                className: 'font-display font-medium text-xl',
                               }}
                               secondary={t('tabs.learn.links.when-to-collect.description')}
                               secondaryTypographyProps={{
-                                className: 'text-sm',
+                                className: 'text-base font-regular',
                               }}
                             />
                             <NavigateNextIcon color="primary" />
@@ -197,11 +197,11 @@ const Home: FC = () => {
                             <ListItemText
                               primary={t('tabs.learn.links.rules-of-thumb.title')}
                               primaryTypographyProps={{
-                                className: 'font-display font-medium',
+                                className: 'font-display font-medium text-xl',
                               }}
                               secondary={t('tabs.learn.links.rules-of-thumb.description')}
                               secondaryTypographyProps={{
-                                className: 'text-sm',
+                                className: 'text-base font-regular',
                               }}
                             />
                             <NavigateNextIcon color="primary" />
@@ -212,11 +212,11 @@ const Home: FC = () => {
                             <ListItemText
                               primary={t('tabs.learn.links.case-study-bonnie.title')}
                               primaryTypographyProps={{
-                                className: 'font-display font-medium',
+                                className: 'font-display font-medium text-xl',
                               }}
                               secondary={t('tabs.learn.links.case-study-bonnie.description')}
                               secondaryTypographyProps={{
-                                className: 'text-sm',
+                                className: 'text-base font-regular',
                               }}
                             />
                             <NavigateNextIcon color="primary" />
@@ -228,7 +228,7 @@ const Home: FC = () => {
                 </TabPanel>
                 <TabPanel value="plan" className="px-0 py-8">
                   <div className="flex flex-col gap-6 md:flex-row">
-                    <Paper className="p-8 md:w-2/5 md:grow">
+                    <Paper className="p-8 md:w-2/6 md:grow">
                       <h2 className="mb-8 font-display text-2xl font-medium text-primary-700 md:text-4xl">
                         {t('tabs.plan.heading')}
                       </h2>
@@ -241,7 +241,7 @@ const Home: FC = () => {
                         </Button>
                       </div>
                     </Paper>
-                    <Paper className="p-8 md:w-3/5">
+                    <Paper className="p-8 md:w-4/6">
                       <h3 className="mb-8 font-display text-xl font-light md:mb-11 md:text-3xl">
                         {t('tabs.plan.linksTitle')}
                       </h3>
@@ -251,11 +251,11 @@ const Home: FC = () => {
                             <ListItemText
                               primary={t('tabs.plan.links.retirement-income-calculator.title')}
                               primaryTypographyProps={{
-                                className: 'font-display font-medium',
+                                className: 'font-display font-medium text-xl',
                               }}
                               secondary={t('tabs.plan.links.retirement-income-calculator.description')}
                               secondaryTypographyProps={{
-                                className: 'text-sm',
+                                className: 'text-base font-regular',
                               }}
                             />
                             <NavigateNextIcon color="primary" />
@@ -266,11 +266,11 @@ const Home: FC = () => {
                             <ListItemText
                               primary={t('tabs.plan.links.oas-eligibility-estimator.title')}
                               primaryTypographyProps={{
-                                className: 'font-display font-medium',
+                                className: 'font-display font-medium text-xl',
                               }}
                               secondary={t('tabs.plan.links.oas-eligibility-estimator.description')}
                               secondaryTypographyProps={{
-                                className: 'text-sm',
+                                className: 'text-base font-regular',
                               }}
                             />
                             <NavigateNextIcon color="primary" />
@@ -282,7 +282,7 @@ const Home: FC = () => {
                 </TabPanel>
                 <TabPanel value="apply" className="px-0 py-8">
                   <div className="flex flex-col gap-6 md:flex-row">
-                    <Paper className="p-8 md:w-2/5 md:grow">
+                    <Paper className="p-8 md:w-2/6 md:grow">
                       <h2 className="mb-8 font-display text-2xl font-medium text-primary-700 md:text-4xl">
                         {t('tabs.apply.heading')}
                       </h2>
@@ -317,7 +317,7 @@ const Home: FC = () => {
                 </TabPanel>
                 <TabPanel value="manage" className="px-0 py-8">
                   <div className="flex flex-col gap-6 md:flex-row">
-                    <Paper className="p-8 md:w-2/5 md:grow">
+                    <Paper className="p-8 md:w-2/6 md:grow">
                       <h2 className="mb-8 font-display text-2xl font-medium text-primary-700 md:text-4xl">
                         {t('tabs.manage.heading')}
                       </h2>
@@ -372,7 +372,7 @@ const Home: FC = () => {
           <Paper variant="outlined" className="p-6">
             <h3 className="mb-4 font-display font-medium md:text-xl">{t('contact-us.cards.find-office.title')}</h3>
             <Divider className="my-4" />
-            <Button component={Link} variant="outlined" href={t('contact-us.cards.find-office.href')}>
+            <Button component={Link} variant="outlined" className="text-primary-700 font-bold border-black border-opacity-10" href={t('contact-us.cards.find-office.href')}>
               {t('contact-us.cards.find-office.link-text')}
             </Button>
           </Paper>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -32,11 +32,13 @@ const LearnCard: FC<LearnCardProps> = ({ desciption, href, id, imageUrl, minRead
           <Image src="/assets/bottom-top.svg" width={34} height={360} className="absolute bottom-0 w-full" alt="" />
         </div>
         <CardContent>
-          <p className="mb-2 font-display text-sm font-bold">{t('min-read', { minRead })}</p>
-          <h3 className="mb-2 font-display text-xl font-bold" id={`${uniqueId}-card-${id}-title`}>
-            {title}
-          </h3>
-          <p className="m-0 text-black/60">{desciption}</p>
+          <div className='p-4'>
+            <p className="mb-2 mt-2 font-display text-sm font-light">{t('min-read', { minRead })}</p>
+            <h3 className="mb-2 font-display text-xl font-bold" id={`${uniqueId}-card-${id}-title`}>
+              {title}
+            </h3>
+            <p className="m-0 text-black/60">{desciption}</p>
+          </div>
         </CardContent>
       </CardActionArea>
     </Card>


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/xxx)

### Description

List of proposed changes:

- Made the following QC Changes

Landing Page
- In dev - tab card is 40% width, should be 33%  or 4/12 columns
- in dev - Top learning links style doesn't match spec for link headers or descriptions
- In dev - "Find a SC office" button border outline is the wrong colour, button text is too small
- Plan tab - Link for OAS benefits estimator should be https://www.canada.ca/en/services/benefits/pub licpensions/cpp/old-age-security/payments.html

Learning Page
- Banner quiz text needs to be updated
- In dev - overline and content cards in general are not to spec
- in dev - update retirement story blurb
- in dev - update Keith's blurb

Main Sources of Retirement
- Key takeaway is capitalized


### What to test for/How to test

### Additional Notes
- Trying to batch these changes as much as possible