### PR TITLE
QC For Main Sources of Retirement Income

### DIFF
--- a/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
+++ b/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
@@ -41,7 +41,7 @@
         "header": "How we top up your CPP retirement pension using Post-Retirement Benefits"
       },
       "choices": {
-        "content": "When you reach age 65, you can choose to stop making post-retirement contributions by filing <a>a form with CRA</a> and giving it to your employer. This will stop you from earning additional PRBs. Together with your retirement pension, PRBs will be adjusted for inflation every year.",
+        "content": "When you reach age 65, you can choose to stop making post-retirement contributions by filing <a>a form with Canada Revenue Agency (CRA)</a> and giving it to your employer. This will stop you from earning additional PRBs. Together with your retirement pension, PRBs will be adjusted for inflation every year.",
         "link": "https://www.canada.ca/en/revenue-agency/services/forms-publications/forms/cpt30.html"
       },
       "differences": {
@@ -163,7 +163,7 @@
       "header": "Savings and pension plans"
     },
     "when-to-start": {
-      "description": "Deciding when to start your public pensions",
+      "description": "Flexible public pensions offer choices for retirement. Learn how to choose and what to consider.",
       "header": "Deciding when to start your public pensions"
     }
   },
@@ -262,9 +262,9 @@
   "personal-retirement-savings": {
     "disclaimer-notice": "<strong>Disclaimer</strong>: This website is meant to give you tips on when to take your public pensions. We do not provide financial advice. Once you have all the information you need, we encourage you to seek help from a financial advisor.",
     "header": "Personal retirement savings",
-    "important-notice": "<strong>Important:</strong> Taking money from TFSA does not count as additional income and will not change the amount of your GIS in the next payment cycle that runs from July to June.",
+    "important-notice": "<strong>Important:</strong> Taking money from a RRSP counts as income that may change your eligibility for Guaranteed Income Supplement (GIS). This could change your next payment cycle that runs from July to June. Taking money from TFSA does not count as income. It will not change the amount of your Guaranteed Income Supplement (GIS).",
     "learn-more": {
-      "content": "To learn more about how much you income you might need in retirement, check out our page on <a>Planning to save for retirement</a>.",
+      "content": "To learn more about how much income you might need in retirement, check out our page on <a>Planning to save for retirement</a>.",
       "link": "/learn/planning-to-save-for-retirement"
     },
     "overview": {

--- a/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
+++ b/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
@@ -10,7 +10,7 @@
           "button-label": "Text alternative for How we top up your CPP retirement pension using Post-Retirement Benefits",
           "caption": "Values presented on the image",
           "description": {
-            "content": "The chart shows changes in monthly payments for people who work for 3 years after starting their CPP retirement pension. It shows that PRBs are added every year to your CPP retirement pensions after you continue working and contributing to the plan.",
+            "content": "The chart shows changes in monthly payments for people who work for 3 years after starting their CPP retirement pension. It shows that PRBs are added every year to your CPP retirement pension after you continue working and contributing to the plan.",
             "header": "Description"
           },
           "header": [
@@ -37,7 +37,7 @@
           ],
           "values-heading": "Values"
         },
-        "footer": "The PRBs are added every year to your CPP retirement pensions after you continue working and contributing to the plan.",
+        "footer": "The PRBs are added every year to your CPP retirement pension after you continue working and contributing to the plan.",
         "header": "How we top up your CPP retirement pension using Post-Retirement Benefits"
       },
       "choices": {
@@ -206,7 +206,7 @@
         "content": "For more details about if you qualify for OAS pension, visit the <a>OAS pension page</a>.",
         "link": "https://www.canada.ca/en/services/benefits/publicpensions/cpp/old-age-security.html"
       },
-      "most-people": "Most people qualify for the OAS pension if they have lived in Canada for more than 10 years after age 18. You will have to be a Canadian citizen or legal resident beforec you can collect your OAS pension."
+      "most-people": "Most people qualify for the OAS pension if they have lived in Canada for more than 10 years after age 18. You will have to be a Canadian citizen or legal resident before you can collect your OAS pension."
     }
   },
   "ongoing-earnings-from-your-job": {

--- a/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
+++ b/frontend/public/locales/en/learn/main-sources-of-retirement-income.json
@@ -262,7 +262,7 @@
   "personal-retirement-savings": {
     "disclaimer-notice": "<strong>Disclaimer</strong>: This website is meant to give you tips on when to take your public pensions. We do not provide financial advice. Once you have all the information you need, we encourage you to seek help from a financial advisor.",
     "header": "Personal retirement savings",
-    "important-notice": "<strong>Important:</strong> Taking money from a RRSP counts as income that may change your eligibility for Guaranteed Income Supplement (GIS). This could change your next payment cycle that runs from July to June. Taking money from TFSA does not count as income. It will not change the amount of your Guaranteed Income Supplement (GIS).",
+    "important-notice": "<strong>Important:</strong> Taking money from an RRSP counts as income that may change your eligibility for Guaranteed Income Supplement (GIS). This could change your next payment cycle that runs from July to June. Taking money from TFSA does not count as income. It will not change the amount of your Guaranteed Income Supplement (GIS).",
     "learn-more": {
       "content": "To learn more about how much income you might need in retirement, check out our page on <a>Planning to save for retirement</a>.",
       "link": "/learn/planning-to-save-for-retirement"

--- a/frontend/public/locales/fr/learn/main-sources-of-retirement-income.json
+++ b/frontend/public/locales/fr/learn/main-sources-of-retirement-income.json
@@ -41,7 +41,7 @@
         "header": "Comment on augmente votre pension de retraite du RPC en utilisant les prestations après-retraite"
       },
       "choices": {
-        "content": "Lorsque vous atteignez l'âge de 65 ans, vous pouvez choisir de cesser de verser des cotisations après la retraite en complètant <a>un formulaire auprès de l'ARC</a> et en le remettant à votre employeur. Cela vous empêchera de gagner des PAR supplémentaires. Avec votre pension de retraite, les PAR seront ajustés chaque année pour tenir compte de l'inflation.",
+        "content": "Lorsque vous atteignez l'âge de 65 ans, vous pouvez choisir de cesser de verser des cotisations après la retraite en complètant <a>un formulaire auprès de l'Agence du revenu du Canada (ARC)</a> et en le remettant à votre employeur. Cela vous empêchera de gagner des PAR supplémentaires. Avec votre pension de retraite, les PAR seront ajustés chaque année pour tenir compte de l'inflation.",
         "link": "https://www.canada.ca/fr/agence-revenu/services/formulaires-publications/formulaires/cpt30.html"
       },
       "differences": {

--- a/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
+++ b/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
@@ -133,24 +133,24 @@ const MainSourcesOfRetirementIncome: FC = () => {
         <h3 id="canada-retirement-income-system" className="h3">
           {t('overview.canada-retirement-income-system.header')}
         </h3>
-        <h3 className="mb-6 bg-primary-600 p-4 font-display text-2xl font-light text-white">
+        <h3 className="mb-6 bg-primary-600 p-4 font-display text-2xl font-bold text-white">
           {t('overview.canada-retirement-income-system.three-pillar-system')}
         </h3>
         <div className="grid gap-6 md:grid-cols-3">
           <div className="flex h-full flex-col gap-6 md:col-span-2">
-            <h4 className="bg-secondary-700 p-4 font-display text-xl font-bold text-white">
+            <h4 className="bg-secondary-700 p-4 font-display text-xl font-light text-white">
               {t('overview.canada-retirement-income-system.public')}
             </h4>
             <div className="grid h-full gap-6 md:grid-cols-2">
               <div className="h-full bg-secondary-100 p-4">
-                <h5 className="mb-2.5 font-display text-xs font-semibold uppercase">
+                <h5 className="mb-2.5 font-display text-sm font-light tracking-widest">
                   {t('overview.canada-retirement-income-system.oas.pillar')}
                 </h5>
                 <p className="mb-2.5 font-bold">{t('overview.canada-retirement-income-system.oas.header')}</p>
                 <p className="text-sm">{t('overview.canada-retirement-income-system.oas.content')}</p>
               </div>
               <div className="h-full bg-secondary-100 p-4">
-                <h5 className="mb-2.5 font-display text-xs font-semibold uppercase">
+                <h5 className="mb-2.5 font-display text-sm font-light tracking-widest">
                   {t('overview.canada-retirement-income-system.cpp-qpp.pillar')}
                 </h5>
                 <p className="mb-2.5 font-bold">{t('overview.canada-retirement-income-system.cpp-qpp.header')}</p>
@@ -159,11 +159,11 @@ const MainSourcesOfRetirementIncome: FC = () => {
             </div>
           </div>
           <div className="flex h-full flex-col gap-6">
-            <h4 className="bg-[#4A0056] p-4 font-display text-xl font-bold text-white">
+            <h4 className="bg-[#4A0056] p-4 font-display text-xl font-light text-white">
               {t('overview.canada-retirement-income-system.private')}
             </h4>
             <div className="h-full bg-[#F0D0FF] p-4">
-              <h5 className="mb-2.5 font-display text-xs font-semibold uppercase">
+              <h5 className="mb-2.5 font-display text-sm font-light tracking-widest">
                 {t('overview.canada-retirement-income-system.workplace.pillar')}
               </h5>
               <p className="mb-2.5 font-bold">{t('overview.canada-retirement-income-system.workplace.header')}</p>
@@ -223,8 +223,8 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6">{t('old-age-security-program.helpful-resources.header')}</h4>
-        <ul className="mb-5 list-disc space-y-2 pl-7">
+        <h4 className="h6 mb-4">{t('old-age-security-program.helpful-resources.header')}</h4>
+        <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
               href: t('old-age-security-program.helpful-resources.overview.link'),
@@ -266,8 +266,8 @@ const MainSourcesOfRetirementIncome: FC = () => {
         <p>{t('guaranteed-income-supplement.monthly')}</p>
         <p>{t('guaranteed-income-supplement.collecting')}</p>
 
-        <h4 className="h6">{t('guaranteed-income-supplement.helpful-resources.header')}</h4>
-        <ul className="mb-5 list-disc space-y-2 pl-7">
+        <h4 className="h6 mb-4">{t('guaranteed-income-supplement.helpful-resources.header')}</h4>
+        <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
               href: t('guaranteed-income-supplement.helpful-resources.overview.link'),
@@ -312,8 +312,8 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6">{t('canada-pension-plan-program.helpful-resources.header')}</h4>
-        <ul className="mb-5 list-disc space-y-2 pl-7">
+        <h4 className="h6 mb-4">{t('canada-pension-plan-program.helpful-resources.header')}</h4>
+        <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
               href: t('canada-pension-plan-program.helpful-resources.overview.link'),
@@ -334,7 +334,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
           ))}
         </ul>
 
-        <h4 className="h6 pb-3">{t('canada-pension-plan-program.cpp-post-retirement-benefit.header')}</h4>
+        <h4 className="h3 py-3">{t('canada-pension-plan-program.cpp-post-retirement-benefit.header')}</h4>
         <p>{t('canada-pension-plan-program.cpp-post-retirement-benefit.overview')}</p>
         <p>{t('canada-pension-plan-program.cpp-post-retirement-benefit.adjustments')}</p>
         <Image
@@ -386,8 +386,8 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6">{t('canada-pension-plan-program.cpp-post-retirement-benefit.helpful-resources.header')}</h4>
-        <ul className="mb-5 list-disc space-y-2 pl-7">
+        <h4 className="h6 mb-4">{t('canada-pension-plan-program.cpp-post-retirement-benefit.helpful-resources.header')}</h4>
+        <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
               href: t('canada-pension-plan-program.cpp-post-retirement-benefit.helpful-resources.cpp.link'),

--- a/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
+++ b/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
@@ -223,7 +223,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6 mb-4">{t('old-age-security-program.helpful-resources.header')}</h4>
+        <h4 className="h4 text-xl mb-4">{t('old-age-security-program.helpful-resources.header')}</h4>
         <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
@@ -266,7 +266,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
         <p>{t('guaranteed-income-supplement.monthly')}</p>
         <p>{t('guaranteed-income-supplement.collecting')}</p>
 
-        <h4 className="h6 mb-4">{t('guaranteed-income-supplement.helpful-resources.header')}</h4>
+        <h4 className="h4 text-xl mb-4">{t('guaranteed-income-supplement.helpful-resources.header')}</h4>
         <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
@@ -312,7 +312,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6 mb-4">{t('canada-pension-plan-program.helpful-resources.header')}</h4>
+        <h4 className="h4 text-xl mb-4">{t('canada-pension-plan-program.helpful-resources.header')}</h4>
         <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {
@@ -334,7 +334,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
           ))}
         </ul>
 
-        <h4 className="h3 py-3">{t('canada-pension-plan-program.cpp-post-retirement-benefit.header')}</h4>
+        <h3 className="h3 py-3">{t('canada-pension-plan-program.cpp-post-retirement-benefit.header')}</h3>
         <p>{t('canada-pension-plan-program.cpp-post-retirement-benefit.overview')}</p>
         <p>{t('canada-pension-plan-program.cpp-post-retirement-benefit.adjustments')}</p>
         <Image
@@ -386,7 +386,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
           />
         </p>
 
-        <h4 className="h6 mb-4">{t('canada-pension-plan-program.cpp-post-retirement-benefit.helpful-resources.header')}</h4>
+        <h4 className="h4 text-xl mb-4">{t('canada-pension-plan-program.cpp-post-retirement-benefit.helpful-resources.header')}</h4>
         <ul className="mb-5 list-disc space-y-1 pl-7">
           {[
             {


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/xxx)

### Description

List of proposed changes:

QC Changes for Main Sources of Retirement Income Include
- in dev -  A three-pillar system table fonts  doesn't match spec
- typo corrected - flagged in Figma (Do you qualify for the OAS pension)
- Spacing for all Helpful resources incorrect
- Header style for What is the CPP Post- Retirement Benefit (PRB)? Changed to H3
- 2 instances where CPP retirement pensions changed to CPP retirement pension
- RRSP Important tip needs to be updated
- Learn more blurb for "Deciding when to start  your public pensions" updated in Figma - typo.
- Typo - extra you in last paragraph in Personal retirement savings. Updated in Figma with  comment
- Expanded CRA name - commented in Figma

### What to test for/How to test

### Additional Notes