### PR TITLE
[frontend] change a11y table to meet specs

### DIFF
--- a/frontend/src/components/AccessibilityGraphContainer.tsx
+++ b/frontend/src/components/AccessibilityGraphContainer.tsx
@@ -7,7 +7,7 @@ import AccessibilityTable, { TableData } from './AccessibilityTable'
 
 export interface AccessibilityGraphContainerProps {
   tableData: TableData
-  description:  React.ReactNode
+  description: React.ReactNode
   descriptionHeading: string
   valuesHeading: string
   buttonLabel: string
@@ -27,19 +27,19 @@ const AccessibilityGraphContainer: React.FC<AccessibilityGraphContainerProps> = 
   }
 
   return (
-    <div className="border-t border-t-primary-500 border-b border-b-primary-500 mb-5">
+    <div className="mb-5 border-b border-t border-b-primary-500 border-t-primary-500">
       <div>
-        <IconButton onClick={handleClick} aria-label={buttonLabel} className='text-primary-500'>
+        <IconButton onClick={handleClick} aria-label={buttonLabel} className="text-primary-500">
           {open ? <ExpandLess /> : <ExpandMore />}
         </IconButton>
         <span>{buttonLabel}</span>
       </div>
       <Collapse in={open}>
-        <div className='py-6'>
-        <h3 className="font-bold pb-4">{descriptionHeading}</h3>
-        <p>{description}</p>
-        <h3 className="font-bold pb-4">{valuesHeading}</h3>
-        <AccessibilityTable tableData={tableData} />
+        <div className="py-6">
+          <h3 className="pb-4 font-bold">{descriptionHeading}</h3>
+          <p>{description}</p>
+          <h3 className="pb-4 font-bold">{valuesHeading}</h3>
+          <AccessibilityTable tableData={tableData} />
         </div>
       </Collapse>
     </div>

--- a/frontend/src/components/AccessibilityTable.tsx
+++ b/frontend/src/components/AccessibilityTable.tsx
@@ -14,13 +14,13 @@ interface TableProps {
 
 const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
   return (
-    <div className='overflow-x-scroll w-full'>
-      <table className="min-w-full border-collapse divide-y border text-left">
-        <caption className="text-left">{tableData.caption}</caption>
+    <div className="w-full overflow-x-scroll">
+      <table className="min-w-full table-fixed border-collapse divide-y border text-left">
+        <caption className="pb-4 text-left">{tableData.caption}</caption>
         <thead className="bg-gray-surface">
           <tr className="divide-x">
-            {tableData.header.map((headerItem,index) => (
-              <th scope="col" key={`${index}-${headerItem}`} className="px-3 py-2.5">
+            {tableData.header.map((headerItem, index) => (
+              <th scope="col" key={`${index}-${headerItem}`} className="w-[150px] px-3 py-2.5">
                 {headerItem}
               </th>
             ))}
@@ -29,7 +29,7 @@ const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
         <tbody className="divide-y">
           {tableData.rows.map((row) => (
             <tr key={row.data.toString()} className="divide-x">
-              {row.data.map((cellData,index) => (
+              {row.data.map((cellData, index) => (
                 <td key={`${index}-${cellData}`} className="px-3 py-2.5">
                   {cellData}
                 </td>


### PR DESCRIPTION
Modification to accessibility table to make columns even width and to add padding to the bottom of the table caption.

Here's how it looks:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/1cb5ae15-de7c-442b-b459-d226f476351e)
