### PR TITLE
[frontend] modify nested accordion styles

### DIFF
--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -65,7 +65,7 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
         <Accordion
           key={task.id}
           disableGutters
-          className='sm:ml-5'
+          className="sm:ml-4"
           expanded={expandedTasks.includes(task.id)}
           onChange={(_, expanded) => {
             onTaskAccordionChange(task.id, expanded)
@@ -78,14 +78,17 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
           }}
         >
           <AccordionSummary
-            className="sm:pl-0 py-2 font-display text-lg font-medium"
+            className="py-2 font-display text-lg font-medium sm:pl-0"
             expandIcon={<ExpandMoreIcon />}
-            sx={{ borderBottom: '1px solid rgba(0, 0, 0, 0.12)' }}
+            sx={{
+              borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+              borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+            }}
           >
             <Checkbox className="-mt-2.5 hidden print:inline" />
             {task.title}
           </AccordionSummary>
-          <AccordionDetails>
+          <AccordionDetails className="py-4 sm:pl-14">
             <TaskCard linksHeader={linksHeader} showCheckbox={false} srTag={srTag} task={task} />
           </AccordionDetails>
         </Accordion>

--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -61,38 +61,33 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
           <div className="text-sm opacity-70">{subSectionTitle}</div>
         </div>
       </AccordionSummary>
-      {tasks.map((task) => (
-        <Accordion
-          key={task.id}
-          disableGutters
-          className="sm:ml-4"
-          expanded={expandedTasks.includes(task.id)}
-          onChange={(_, expanded) => {
-            onTaskAccordionChange(task.id, expanded)
-          }}
-          sx={{
-            'boxShadow': '0',
-            '.MuiAccordionSummary-root:focus': {
-              backgroundColor: 'transparent',
-            },
-          }}
-        >
-          <AccordionSummary
-            className="py-2 font-display text-lg font-medium sm:pl-0"
-            expandIcon={<ExpandMoreIcon />}
+      <div className="divide-y">
+        {tasks.map((task) => (
+          <Accordion
+            key={task.id}
+            disableGutters
+            className="divide-y before:hidden sm:ml-4"
+            expanded={expandedTasks.includes(task.id)}
+            onChange={(_, expanded) => {
+              onTaskAccordionChange(task.id, expanded)
+            }}
             sx={{
-              borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
-              borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+              'boxShadow': '0',
+              '.MuiAccordionSummary-root:focus': {
+                backgroundColor: 'transparent',
+              },
             }}
           >
-            <Checkbox className="-mt-2.5 hidden print:inline" />
-            {task.title}
-          </AccordionSummary>
-          <AccordionDetails className="py-4 sm:pl-14">
-            <TaskCard linksHeader={linksHeader} showCheckbox={false} srTag={srTag} task={task} />
-          </AccordionDetails>
-        </Accordion>
-      ))}
+            <AccordionSummary className="py-2 font-display text-lg font-medium sm:pl-0" expandIcon={<ExpandMoreIcon />}>
+              <Checkbox className="-mt-2.5 hidden print:inline" />
+              {task.title}
+            </AccordionSummary>
+            <AccordionDetails className="py-4 sm:pl-14">
+              <TaskCard linksHeader={linksHeader} showCheckbox={false} srTag={srTag} task={task} />
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </div>
     </Accordion>
   )
 }


### PR DESCRIPTION
The intent of this PR is to align the nested accordion component's styles to match the Figma mockup.  Additional padding/margin added where it's needed as well as borders.

Here's how it looks now:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/cf5d85e8-2e3d-4462-8b4c-8ce63e053023)
