### PR TITLE
[frontend] change filter tag order

### DIFF
--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -80,11 +80,10 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
       })
     })
 
-    return sortBy(tags, [
-      function (o) {
-        return o.code
-      },
-    ])
+    return [
+      ...tags.filter((tag) => tag.code !== 'other-benefits').sort((a, b) => a.code.localeCompare(b.code)),
+      ...tags.filter((tag) => tag.code === 'other-benefits'),
+    ]
   }, [applyingBenefits.tasks, beforeRetiring.tasks, receivingBenefits.tasks])
 
   function handleChange(e: ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
### Description

Changed the order of the tags filter tasks in the checklist page.  Lexicographical sort applies to anything other than "other benefits", whilst "other benefits must be at the end of the list.

List of proposed changes:
- modified sort logic