### PR TITLE
[frontend] task tag sr-only

### DIFF
--- a/frontend/public/locales/en/checklist.json
+++ b/frontend/public/locales/en/checklist.json
@@ -28,5 +28,6 @@
   },
   "print": "Print",
   "restart-quiz": "Restart quiz",
-  "show-filters": "Show filters"
+  "show-filters": "Show filters",
+  "sr-tag": "Task tag"
 }

--- a/frontend/public/locales/fr/checklist.json
+++ b/frontend/public/locales/fr/checklist.json
@@ -28,5 +28,6 @@
   },
   "print": "Imprimer",
   "restart-quiz": "Relancez ce questionnaire",
-  "show-filters": "Afficher les filtres"
+  "show-filters": "Afficher les filtres",
+  "sr-tag": "L'étiquette de tâche"
 }

--- a/frontend/src/components/NestedAccordion.tsx
+++ b/frontend/src/components/NestedAccordion.tsx
@@ -15,6 +15,7 @@ interface NestedAccordionProps {
   onTaskGroupAccordionChange: (id: number, expanded: boolean) => void
   sectionTitle: string
   subSectionTitle: string
+  srTag: string
   tasks: ReadonlyArray<TaskDto>
 }
 
@@ -27,6 +28,7 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
   onTaskGroupAccordionChange,
   sectionTitle,
   subSectionTitle,
+  srTag,
   tasks = [],
 }) => {
   return (
@@ -84,7 +86,7 @@ const NestedAccordion: React.FC<NestedAccordionProps> = ({
             {task.title}
           </AccordionSummary>
           <AccordionDetails>
-            <TaskCard linksHeader={linksHeader} showCheckbox={false} task={task} />
+            <TaskCard linksHeader={linksHeader} showCheckbox={false} srTag={srTag} task={task} />
           </AccordionDetails>
         </Accordion>
       ))}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -2,14 +2,16 @@ import { Chip, Link } from '@mui/material'
 
 import { TaskDto } from '../lib/types'
 import Markdown from './Markdown'
+import React from 'react'
 
 interface TaskCardProps {
   linksHeader: string
   showCheckbox?: boolean
+  srTag: string
   task: TaskDto
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ linksHeader, showCheckbox, task }) => {
+const TaskCard: React.FC<TaskCardProps> = ({ linksHeader, showCheckbox, srTag, task }) => {
   return (
     <>
       {showCheckbox && <input type="checkbox" className="relative top-2 mb-4 h-6 w-6" />}
@@ -30,7 +32,10 @@ const TaskCard: React.FC<TaskCardProps> = ({ linksHeader, showCheckbox, task }) 
       {task.tags.length > 0 && (
         <div className="flex gap-2">
           {task.tags.map((tag) => (
-            <Chip key={tag.code} label={tag.title} />
+            <React.Fragment key={tag.code}>
+              <span className="sr-only">{srTag}:</span>
+              <Chip key={tag.code} label={tag.title} />
+            </React.Fragment>
           ))}
         </div>
       )}

--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -218,7 +218,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
                   aria-label={t('show-filters')}
                 >
                   {expanded ? <ExpandLess className="hidden md:block" /> : <ExpandMore className="hidden md:block" />}
-                  <FilterList className="h-10 w-10 rounded-full bg-[#008490] p-1 text-white hover:bg-[#00545f] md:hidden" />
+                  <FilterList className="hover:bg-[#00545f] h-10 w-10 rounded-full bg-[#008490] p-1 text-white md:hidden" />
                 </IconButton>
               </div>
               <Collapse in={expanded}>
@@ -249,6 +249,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               onTaskGroupAccordionChange={handleOnTaskGroupAccordionChange}
               sectionTitle={beforeRetiring.title}
               subSectionTitle={beforeRetiring.subTitle}
+              srTag={t('sr-tag')}
               tasks={beforeRetiring.tasks.filter((task) => filterTasksByTag(task, filters))}
             />
             <NestedAccordion
@@ -260,6 +261,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               onTaskGroupAccordionChange={handleOnTaskGroupAccordionChange}
               sectionTitle={applyingBenefits.title}
               subSectionTitle={applyingBenefits.subTitle}
+              srTag={t('sr-tag')}
               tasks={applyingBenefits.tasks.filter((task) => filterTasksByTag(task, filters))}
             />
             <NestedAccordion
@@ -271,6 +273,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               onTaskGroupAccordionChange={handleOnTaskGroupAccordionChange}
               sectionTitle={receivingBenefits.title}
               subSectionTitle={receivingBenefits.subTitle}
+              srTag={t('sr-tag')}
               tasks={receivingBenefits.tasks.filter((task) => filterTasksByTag(task, filters))}
             />
             <div className="mt-4 lg:hidden">


### PR DESCRIPTION
The premise of this PR is to introduce a screen reader only label to each chip (A.K.A. the task tags) in the checklist.  This will make for a more accessible experience to screen reader users.  

## Proposed Changes:
- added 'sr-only' span to the Chip component
