### PR TITLE
[frontend] fix ajv:validate script command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "test:unit": "jest",
     "test:coverage": "jest --coverage --forceExit",
     "typecheck": "tsc",
-    "ajv:validate": "ts-node --compilerOptions \"{\\\"module\\\":\\\"CommonJS\\\"}\" ./src/data/tasks-validation.ts | pino-pretty"
+    "ajv:validate": "ts-node --compilerOptions \"{\\\"module\\\":\\\"CommonJS\\\"}\" ./src/data/tasks-validation.ts"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",


### PR DESCRIPTION
### Description

List of proposed changes:

-  fix ajv:validate script command by removing `pino-pretty` (exit code is always `0` with it)