### PR TITLE
[frontend] adjust a11y table and container spacing

### DIFF
--- a/frontend/src/components/AccessibilityGraphContainer.tsx
+++ b/frontend/src/components/AccessibilityGraphContainer.tsx
@@ -29,16 +29,20 @@ const AccessibilityGraphContainer: React.FC<AccessibilityGraphContainerProps> = 
   return (
     <div className="my-8 border-b border-t border-b-primary-500 border-t-primary-500">
       <div>
-        <IconButton onClick={handleClick} aria-label={buttonLabel} className="text-primary-500 w-full justify-start rounded-none">
+        <IconButton
+          onClick={handleClick}
+          aria-label={buttonLabel}
+          className="w-full justify-start rounded-none text-primary-500"
+        >
           {open ? <ExpandLess /> : <ExpandMore />}
-        <span className='text-base font-body text-black'>{buttonLabel}</span>
+          <span className="font-body text-base text-black/[0.87]">{buttonLabel}</span>
         </IconButton>
       </div>
       <Collapse in={open}>
-        <div className="py-6">
+        <div className="pb-8 pt-4">
           <h3 className="pb-4 font-bold">{descriptionHeading}</h3>
           <p>{description}</p>
-          <h3 className="pb-4 font-bold">{valuesHeading}</h3>
+          <h3 className="pb-4 pt-8 font-bold">{valuesHeading}</h3>
           <AccessibilityTable tableData={tableData} />
         </div>
       </Collapse>


### PR DESCRIPTION
This is a purely cosmetic change that addresses one of the bugs flagged.  The spacing in the accessibility container needed to be adjusted. This PR resolves that issue and aligns the application with the mockups.  