### PR TITLE
[frontend] update accessibility header styles and fix typos in case study headers

### DIFF
--- a/frontend/public/locales/en/learn/case-studies/bonnie.json
+++ b/frontend/public/locales/en/learn/case-studies/bonnie.json
@@ -3,7 +3,7 @@
     "accessibility": {
       "button-label": "Text alternative for Earnings from work and OAS pension",
       "caption": "Values presented on the image:",
-      "header": ["Age", "Target monthly Income in Retirement", "Earnings from work", "Monthly OAS pension"],
+      "header": ["Age", "Target monthly income in retirement", "Earnings from work", "Monthly OAS pension"],
       "rows": [
         {
           "data": ["60", "$5,583", "$5,583", "-"]
@@ -225,8 +225,8 @@
         "Age",
         "Target monthly income in retirement",
         "Earnings from work",
-        "OAS monthly pension",
-        "CPP monthly pension",
+        "Monthly OAS pension",
+        "Monthly CPP pension",
         "Retirement savings"
       ],
       "rows": [
@@ -474,7 +474,7 @@
     "accessibility": {
       "button-label": "Text alternative for Earnings from work",
       "caption": "Values presented on the image:",
-      "header": ["Age", "Target monthly Income in Retirement", "Earnings from work"],
+      "header": ["Age", "Target monthly income in Retirement", "Earnings from work"],
       "rows": [
         {
           "data": ["60", "$5,583", "$5,583"]

--- a/frontend/public/locales/en/learn/case-studies/fred.json
+++ b/frontend/public/locales/en/learn/case-studies/fred.json
@@ -13,7 +13,7 @@
       "accessibility": {
         "button-label": "Text alternative for Fred's CPP lifetime pension at age 86",
         "caption": "Values presented on the image:",
-        "header": ["Age when Fred starts taking his CPP pension", "Fred's CPP lifetime pension at age 86"],
+        "header": ["Age when Fred starts collecting his CPP retirement pension", "Lifetime CPP retirement pension"],
         "rows": [
           {
             "data": ["60", "$259,584"]
@@ -33,7 +33,7 @@
       "accessibility": {
         "button-label": "Text alternative for Fred's CPP monthly pension",
         "caption": "Values presented on the image:",
-        "header": ["Age when Fred starts taking his CPP pension", "Fred's CPP monthly pension"],
+        "header": ["Age when Fred starts collecting his CPP retirement pension", "Monthly CPP retirement pension"],
         "rows": [
           {
             "data": ["60", "$832"]
@@ -109,7 +109,7 @@
       "accessibility": {
         "button-label": "Text alternative for Fred's OAS lifetime pension at age 86",
         "caption": "Values presented on the image:",
-        "header": ["Age when Fred starts taking his OAS pension", "Fred's lifetime OAS pension"],
+        "header": ["Age when Fred starts collecting his OAS pension", "Lifetime OAS pension"],
         "rows": [
           {
             "data": ["65", "$191,545"]
@@ -133,7 +133,7 @@
       "accessibility": {
         "button-label": "Text alternative for Fred's OAS monthly pension",
         "caption": "Values presented on the image:",
-        "header": ["Age when Fred starts taking his OAS pension", "Fred's OAS monthly pension amount"],
+        "header": ["Age when Fred starts collecting his OAS pension", "Monthly OAS pension amount"],
         "rows": [
           {
             "data": ["65", "$691"]

--- a/frontend/src/components/AccessibilityGraphContainer.tsx
+++ b/frontend/src/components/AccessibilityGraphContainer.tsx
@@ -40,9 +40,9 @@ const AccessibilityGraphContainer: React.FC<AccessibilityGraphContainerProps> = 
       </div>
       <Collapse in={open}>
         <div className="pb-8 pt-4">
-          <h3 className="pb-4 font-bold">{descriptionHeading}</h3>
+          <h3 className="pb-4 font-bold font-display text-lg">{descriptionHeading}</h3>
           <p>{description}</p>
-          <h3 className="pb-4 pt-8 font-bold">{valuesHeading}</h3>
+          <h3 className="pb-4 pt-8 font-bold font-display text-lg">{valuesHeading}</h3>
           <AccessibilityTable tableData={tableData} />
         </div>
       </Collapse>

--- a/frontend/src/components/AccessibilityTable.tsx
+++ b/frontend/src/components/AccessibilityTable.tsx
@@ -17,7 +17,7 @@ const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
     <div className="w-full overflow-x-scroll">
       <table className="min-w-full table-fixed border-collapse divide-y border text-left">
         <caption className="pb-4 text-left">{tableData.caption}</caption>
-        <thead className="bg-gray-surface">
+        <thead className="bg-gray-surface font-display text-xl">
           <tr className="divide-x">
             {tableData.header.map((headerItem, index) => (
               <th scope="col" key={`${index}-${headerItem}`} className="w-[150px] px-3 py-2.5">


### PR DESCRIPTION
Small changes to align the accessibility headers with the mockups and to address some typos in the headers for Bonnie and Fred's case study.