### PR TITLE
[frontend] remove home contact us section

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -3,36 +3,6 @@
     "text": "It's never too early or too late to learn about your retirement options and plan for your future. Find out about public pensions, when to collect them and tips to consider for your retirement income.",
     "title": "Learn and plan for your retirement"
   },
-  "contact-us": {
-    "cards": {
-      "call-us": {
-        "description": "You can reach us at the following numbers:",
-        "outside": {
-          "description": "The hours of operation are 8:30 am to 5 pm Eastern time, Monday to Friday.",
-          "href": "https://www.canada.ca/en/contact/international.html",
-          "number": "Call 1\u00a0800\u00a0O\u2011Canada from abroad",
-          "title": "From outside Canada:"
-        },
-        "title": "Call us",
-        "toll-free": {
-          "description": "The hours of operation are 8:30 am to 5 pm local time, Monday to Friday.",
-          "number": "1\u00a0800\u00a0O\u2011Canada (1\u2011800\u2011622\u20116232)",
-          "title": "Telephone:"
-        },
-        "tty": {
-          "number": "1\u2011800\u2011926\u20119105",
-          "title": "TTY:"
-        }
-      },
-      "find-office": {
-        "href": "https://www.servicecanada.gc.ca/tbsc-fsco/sc-hme.jsp",
-        "link-text": "Find a Service Canada office near you",
-        "title": "Find an office"
-      }
-    },
-    "description": "There are many ways to reach us about your public pensions.",
-    "title": "Contact us"
-  },
   "header": "Learn and plan for your retirement",
   "meta": {
     "description": "It's never too early or too late to learn about your retirement options and plan for your future. Find out about public pensions, when to take them and tips to consider for your retirement income."

--- a/frontend/public/locales/fr/home.json
+++ b/frontend/public/locales/fr/home.json
@@ -3,36 +3,6 @@
     "text": "Il n'est jamais trop tôt ni trop tard pour s'informer sur les options de retraite qui s'offrent à vous et planifier votre avenir. Renseignez-vous sur les pensions publiques, le meilleur moment pour commencer à les recevoir et les conseils pour maximiser votre revenu de retraite.",
     "title": "Informez-vous sur votre retraite et planifiez en conséquence"
   },
-  "contact-us": {
-    "cards": {
-      "call-us": {
-        "description": "Vous pouvez nous joindre aux numéros suivants\u00a0:",
-        "outside": {
-          "description": "Les heures d'ouverture sont de de 8 h à 17 h, heure locale, du lundi au vendredi.",
-          "href": "https://www.canada.ca/fr/contact/international.html",
-          "number": "Composer le 1\u00a0800\u00a0O\u2011Canada à l'étranger",
-          "title": "À l'extérieur du Canada\u00a0:"
-        },
-        "title": "Appelez-nous",
-        "toll-free": {
-          "description": "Les heures d'ouverture sont de 8 h à 17 h, heure locale, du lundi au vendredi.",
-          "number": "1\u00a0800\u00a0O\u2011Canada (1\u2011800\u2011622\u20116232)",
-          "title": "Téléphone\u00a0:"
-        },
-        "tty": {
-          "number": "1\u2011800\u2011926\u20119105",
-          "title": "ATS\u00a0:"
-        }
-      },
-      "find-office": {
-        "href": "https://www.servicecanada.gc.ca/tbsc-fsco/sc-hme.jsp?lang=fra",
-        "link-text": "Trouver un Centre Service Canada près de chez vous",
-        "title": "Trouver un bureau"
-      }
-    },
-    "description": "Il y a plusieurs façons que vous pouvez communiquer avec nous pour obtenir des renseignements au sujet de vos pensions publiques",
-    "title": "Communiquez avec nous"
-  },
   "header": "Informez-vous sur votre retraite et planifiez en conséquence",
   "meta": {
     "description": "Il n'est jamais trop tôt ni trop tard pour s'informer sur les options de retraite qui s'offrent à vous et planifier votre avenir. Renseignez-vous sur les pensions publiques, le meilleur moment pour commencer à les recevoir et les conseils pour maximiser votre revenu de retraite."

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -11,7 +11,6 @@ import {
   ListItem,
   ListItemButton,
   ListItemText,
-  Link as MuiLink,
   Paper,
   Tab,
   useMediaQuery,
@@ -245,9 +244,13 @@ const Home: FC = () => {
                       <h3 className="mb-8 font-display text-xl font-light md:mb-11 md:text-3xl">
                         {t('tabs.plan.linksTitle')}
                       </h3>
-                      <List disablePadding className='ml-4'>
+                      <List disablePadding className="ml-4">
                         <ListItem disablePadding className="border-b">
-                          <ListItemButton className='pl-0' href={t('tabs.plan.links.retirement-income-calculator.url')} component={Link}>
+                          <ListItemButton
+                            className="pl-0"
+                            href={t('tabs.plan.links.retirement-income-calculator.url')}
+                            component={Link}
+                          >
                             <ListItemText
                               primary={t('tabs.plan.links.retirement-income-calculator.title')}
                               primaryTypographyProps={{
@@ -262,7 +265,11 @@ const Home: FC = () => {
                           </ListItemButton>
                         </ListItem>
                         <ListItem disablePadding className="border-b">
-                          <ListItemButton className='pl-0' href={t('tabs.plan.links.oas-eligibility-estimator.url')} component={Link}>
+                          <ListItemButton
+                            className="pl-0"
+                            href={t('tabs.plan.links.oas-eligibility-estimator.url')}
+                            component={Link}
+                          >
                             <ListItemText
                               primary={t('tabs.plan.links.oas-eligibility-estimator.title')}
                               primaryTypographyProps={{
@@ -287,10 +294,14 @@ const Home: FC = () => {
                         {t('tabs.apply.heading')}
                       </h2>
                       <Divider className="mb-8" />
-                      <p className='mb-8'>{t('tabs.apply.description.text')}</p>
-                      <List disablePadding className='ml-4'>
+                      <p className="mb-8">{t('tabs.apply.description.text')}</p>
+                      <List disablePadding className="ml-4">
                         <ListItem disablePadding className="border-b">
-                          <ListItemButton className='pl-0' href={t('tabs.apply.description.links.how-to-apply.url')} component={Link}>
+                          <ListItemButton
+                            className="pl-0"
+                            href={t('tabs.apply.description.links.how-to-apply.url')}
+                            component={Link}
+                          >
                             <ListItemText
                               primary={t('tabs.apply.description.links.how-to-apply.title')}
                               primaryTypographyProps={{
@@ -301,7 +312,11 @@ const Home: FC = () => {
                           </ListItemButton>
                         </ListItem>
                         <ListItem disablePadding className="border-b">
-                          <ListItemButton className='pl-0' href={t('tabs.apply.description.links.oas-apply.url')} component={Link}>
+                          <ListItemButton
+                            className="pl-0"
+                            href={t('tabs.apply.description.links.oas-apply.url')}
+                            component={Link}
+                          >
                             <ListItemText
                               primary={t('tabs.apply.description.links.oas-apply.title')}
                               primaryTypographyProps={{
@@ -341,47 +356,6 @@ const Home: FC = () => {
             </div>
           </TabContext>
         </section>
-
-        <Container>
-          <h2 className="h2 text-primary-700">{t('contact-us.title')}</h2>
-          <p className="mb-8">{t('contact-us.description')}</p>
-          <Paper variant="outlined" className="mb-6 p-6">
-            <h3 className="mb-4 font-display font-medium md:text-xl">{t('contact-us.cards.call-us.title')}</h3>
-            <Divider className="my-4" />
-            <p>{t('contact-us.cards.call-us.description')}</p>
-            <div className="grid lg:grid-cols-2">
-              <p>
-                <strong>{t('contact-us.cards.call-us.toll-free.title')}</strong>
-                {' ' + t('contact-us.cards.call-us.toll-free.number')}
-              </p>
-              <p>
-                <strong>{t('contact-us.cards.call-us.tty.title')}</strong>
-                {' ' + t('contact-us.cards.call-us.tty.number')}
-              </p>
-            </div>
-            <p>{t('contact-us.cards.call-us.toll-free.description')}</p>
-            <Divider className="my-4" />
-            <p>
-              <strong>{t('contact-us.cards.call-us.outside.title')}</strong>{' '}
-              <MuiLink component={Link} href={t('contact-us.cards.call-us.outside.href')}>
-                {t('contact-us.cards.call-us.outside.number')}
-              </MuiLink>
-            </p>
-            <p className="m-0">{t('contact-us.cards.call-us.outside.description')}</p>
-          </Paper>
-          <Paper variant="outlined" className="p-6">
-            <h3 className="mb-4 font-display font-medium md:text-xl">{t('contact-us.cards.find-office.title')}</h3>
-            <Divider className="my-4" />
-            <Button
-              component={Link}
-              variant="outlined"
-              className="border-black tracking-wider text-base border-opacity-10 font-bold text-primary-700"
-              href={t('contact-us.cards.find-office.href')}
-            >
-              {t('contact-us.cards.find-office.link-text')}
-            </Button>
-          </Paper>
-        </Container>
       </Layout>
     </>
   )


### PR DESCRIPTION
An Pham asked to remove the "Contact us" section from the home page.

![image](https://github.com/DTS-STN/senior-journey/assets/114004123/66dc9363-a256-4a11-9357-77876cf63ef9)


### Description

List of proposed changes:

- remove home contact us section