### PR TITLE
[frontend] add adobe analytic data attributes

### DIFF
--- a/frontend/src/components/TaskGroupAccordion.tsx
+++ b/frontend/src/components/TaskGroupAccordion.tsx
@@ -57,6 +57,7 @@ export const TaskGroupAccordion: React.FC<TaskGroupAccordionProps> = ({
         className="group/task-group aria-disabled:opacity-[0.54]"
         aria-disabled={disabled}
         open={disabled ? false : expanded}
+        data-gc-analytics-expand={sectionTitle}
       >
         <summary className="flex cursor-pointer  gap-2 bg-primary-800 px-4 py-5 text-white focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary-700 group-aria-disabled/task-group:pointer-events-none group-aria-disabled/task-group:select-none">
           <div className="grow">

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -105,10 +105,30 @@ const Home: FC = () => {
             <Paper elevation={4} square className="relative">
               {!extraSmall && (
                 <TabList onChange={handleChange} scrollButtons="auto" centered>
-                  <Tab value="learn" label={t('tabs.learn.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                  <Tab value="plan" label={t('tabs.plan.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                  <Tab value="apply" label={t('tabs.apply.title')} className="px-10 pt-4 text-lg md:text-2xl" />
-                  <Tab value="manage" label={t('tabs.manage.title')} className="px-10 pt-4 text-lg md:text-2xl" />
+                  <Tab
+                    value="learn"
+                    label={t('tabs.learn.title')}
+                    data-gc-analytics-tabopen={t('tabs.learn.title')}
+                    className="px-10 pt-4 text-lg md:text-2xl"
+                  />
+                  <Tab
+                    value="plan"
+                    label={t('tabs.plan.title')}
+                    data-gc-analytics-tabopen={t('tabs.plan.title')}
+                    className="px-10 pt-4 text-lg md:text-2xl"
+                  />
+                  <Tab
+                    value="apply"
+                    label={t('tabs.apply.title')}
+                    data-gc-analytics-tabopen={t('tabs.apply.title')}
+                    className="px-10 pt-4 text-lg md:text-2xl"
+                  />
+                  <Tab
+                    value="manage"
+                    label={t('tabs.manage.title')}
+                    data-gc-analytics-tabopen={t('tabs.manage.title')}
+                    className="px-10 pt-4 text-lg md:text-2xl"
+                  />
                 </TabList>
               )}
               {extraSmall && (
@@ -141,12 +161,25 @@ const Home: FC = () => {
                         },
                       }}
                     >
-                      <Tab value="learn" label={t('tabs.learn.title')} />
-                      <Tab value="plan" label={t('tabs.plan.title')} />
+                      <Tab
+                        value="learn"
+                        label={t('tabs.learn.title')}
+                        data-gc-analytics-tabopen={t('tabs.learn.title')}
+                      />
+                      <Tab value="plan" label={t('tabs.plan.title')} data-gc-analytics-tabopen={t('tabs.plan.title')} />
                       ,
-                      <Tab value="apply" label={t('tabs.apply.title')} />
+                      <Tab
+                        value="apply"
+                        label={t('tabs.apply.title')}
+                        data-gc-analytics-tabopen={t('tabs.apply.title')}
+                      />
                       ,
-                      <Tab value="manage" label={t('tabs.manage.title')} />,
+                      <Tab
+                        value="manage"
+                        label={t('tabs.manage.title')}
+                        data-gc-analytics-tabopen={t('tabs.manage.title')}
+                      />
+                      ,
                     </TabList>
                   </Collapse>
                 </>


### PR DESCRIPTION
## [ADO-484](https://dev.azure.com/JourneyLab/SeniorsJourney/_sprints/taskboard/DTS/SeniorsJourney/DTS/DTS%20-%20Sprint%208?workitem=484)

### Description

Add custom data attributes to components that the AA team shared with us.

List of proposed changes:
- add custom data-gc attribute to learn tabs on home page
- add custom data-gc attribute to checklist timeline accordions

### Additional Notes

I need to add in the ones for the quiz. This will be addressed in a separate PR.  