### PR TITLE
[frontend] change padding on privacy links in footer

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -141,9 +141,9 @@ const Footer: FC<FooterProps> = ({
               {footerNavHeader}
             </h3>
             <div className="flex items-end justify-between sm:items-center">
-              <ul className="flex flex-col gap-3 marker:text-xs sm:list-inside sm:list-disc sm:flex-row">
+              <ul className="flex flex-col gap-3 marker:text-xs sm:list-disc sm:flex-row">
                 {links.map(({ link, linkText }) => (
-                  <li key={link} className="sm:first:list-none">
+                  <li key={link} className="sm:first:pr-3 sm:pl-2 sm:first:list-none sm:first:pl-0">
                     <MuiLink
                       color="primary"
                       underline="hover"


### PR DESCRIPTION
This PR intends to address the padding between the privacy and terms and conditions links in the footer.

**After:**
![image](https://github.com/DTS-STN/senior-journey/assets/48450599/9be6a548-c10c-4bfe-883d-4de146427a69)

**Before:**
![image](https://github.com/DTS-STN/senior-journey/assets/48450599/77c02a0f-e5ae-423e-8d7a-d51c741d47a9)

