### PR TITLE
[frontend] image placeholder blur

### DIFF
--- a/frontend/src/components/HeroBanner.tsx
+++ b/frontend/src/components/HeroBanner.tsx
@@ -1,9 +1,13 @@
 import { FC, PropsWithChildren } from 'react'
 
-import Image, { ImageProps } from 'next/image'
+import Image, { StaticImageData } from 'next/image'
 
 export interface HeroBannerProps extends PropsWithChildren {
-  imageProps: ImageProps
+  imageProps: {
+    alt?: string
+    className?: string
+    src: StaticImageData
+  }
   className?: string
 }
 
@@ -30,12 +34,11 @@ export const HeroBanner: FC<HeroBannerProps> = ({ children, imageProps, classNam
               width={17}
             />
             <Image
-              {...{
-                ...imageProps,
-                alt: imageProps.alt ?? '',
-                className: `h-full w-full object-cover ${imageProps.className ?? ''}`,
-                priority: imageProps.priority ?? true,
-              }}
+              alt={imageProps.alt ?? ''}
+              className={`object-cover ${imageProps.className ?? ''}`}
+              fill
+              placeholder="blur"
+              src={imageProps.src}
             />
             <Image
               alt=""

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -17,7 +17,13 @@ const adobeAnalyticsConfigured = process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_
 const devmodeEnabled = process.env.NODE_ENV !== 'production'
 
 // see https://experienceleague.adobe.com/docs/id-service/using/reference/csp.html
-const defaultAdobeAnalyticsDomains = ['*.demdex.net', 'assets.adobedtm.com', 'canada.sc.omtrdc.net', 'cm.everesttech.net', 'code.jquery.com']
+const defaultAdobeAnalyticsDomains = [
+  '*.demdex.net',
+  'assets.adobedtm.com',
+  'canada.sc.omtrdc.net',
+  'cm.everesttech.net',
+  'code.jquery.com',
+]
 
 /**
  * A function that returns a string of Adobe Analytics domains.
@@ -58,6 +64,9 @@ function generateCsp(nonce: string): string {
     'style-src': ["'self'"],
   }
 
+  // required by Next.js Image with placeholder="blur"
+  contentSecurityPolicy['img-src']?.push('data:')
+
   // required by MUI; TODO: figure out how to tighten this up
   // see: https://mui.com/material-ui/guides/content-security-policy/
   contentSecurityPolicy['style-src']?.push("'unsafe-eval'", "'unsafe-inline'")
@@ -85,7 +94,9 @@ function generateCsp(nonce: string): string {
   }
 
   if (!adobeAnalyticsConfigured) {
-    log.debug(`Adobe Analytics configuration not detected, adding 'nonce-${nonce}' directives to Content-Security-Policy`)
+    log.debug(
+      `Adobe Analytics configuration not detected, adding 'nonce-${nonce}' directives to Content-Security-Policy`
+    )
     contentSecurityPolicy['script-src']?.push(`'nonce-${nonce}'`)
   }
 
@@ -110,15 +121,22 @@ export default function MyDocument({ emotionStyleTags, locale, nonce }: MyDocume
         <link rel="icon" href="/assets/favicon.ico" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap&family=Patua+One:wght@100;400;700&display=swap" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap&family=Patua+One:wght@100;400;700&display=swap"
+        />
         <meta name="emotion-insertion-point" content="" />
         {emotionStyleTags}
       </Head>
       <body>
         <Main />
         <NextScript nonce={nonce} />
-        {adobeAnalyticsConfigured && <Script strategy="beforeInteractive" src="https://code.jquery.com/jquery-3.6.3.min.js" />}
-        {adobeAnalyticsConfigured && <Script strategy="beforeInteractive" src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_SRC} />}
+        {adobeAnalyticsConfigured && (
+          <Script strategy="beforeInteractive" src="https://code.jquery.com/jquery-3.6.3.min.js" />
+        )}
+        {adobeAnalyticsConfigured && (
+          <Script strategy="beforeInteractive" src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_SRC} />
+        )}
       </body>
     </Html>
   )

--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -21,6 +21,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 
+import checklistBannerImage from '../../../public/assets/checklist-banner.jpg'
 import { HeroBanner } from '../../components/HeroBanner'
 import Layout from '../../components/Layout'
 import { TaskGroupAccordion } from '../../components/TaskGroupAccordion'
@@ -148,15 +149,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
         hideHeader="print"
       >
         <div className="hidden md:block">
-          <HeroBanner
-            className="h-[215px] grid-rows-1"
-            imageProps={{
-              alt: '',
-              height: 427,
-              src: '/assets/checklist-banner.jpg',
-              width: 640,
-            }}
-          >
+          <HeroBanner className="h-[215px] grid-rows-1" imageProps={{ src: checklistBannerImage }}>
             <h1 className="font-display text-4xl font-bold text-primary-700 md:text-6xl">{t('header')}</h1>
           </HeroBanner>
         </div>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -25,6 +25,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import urlcat from 'urlcat'
 
+import landingPageImage from '../../public/assets/landing-page.jpg'
 import Container from '../components/Container'
 import { HeroBanner } from '../components/HeroBanner'
 import Layout from '../components/Layout'
@@ -82,15 +83,7 @@ const Home: FC = () => {
       />
       <Layout contained={false}>
         <Container className="mb-8 md:mb-12">
-          <HeroBanner
-            imageProps={{
-              alt: '',
-              className: 'md:object-right-bottom',
-              height: 427,
-              src: '/assets/landing-page.jpg',
-              width: 640,
-            }}
-          >
+          <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: landingPageImage }}>
             <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
               {t('banner.title')}
             </h1>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -1,13 +1,22 @@
 import { FC, useId } from 'react'
 
-import { Button, Card, CardActionArea, CardContent, CardMedia } from '@mui/material'
+import { Button, Card, CardActionArea, CardContent } from '@mui/material'
 import { GetServerSideProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
-import Image from 'next/image'
+import Image, { StaticImageData } from 'next/image'
 import Link from 'next/link'
 
+import bonnieDelaysToReduceTheSavingsSheNeedsSmImage from '../../../public/assets/bonnie-delays-to-reduce-the-savings-she-needs-sm.jpg'
+import decidingWhenToStartYourPublicPensionsSmImage from '../../../public/assets/deciding-when-to-start-your-public-pensions-sm.jpg'
+import fredDecidesWhenToTakeHisPensionsSmImage from '../../../public/assets/fred-decides-when-to-take-his-pensions-sm.jpg'
+import goingFromWorkToRetirementSmImage from '../../../public/assets/going-from-work-to-retirement-sm.jpg'
+import keithCombinesHisWorkWithHisPublicPensionsSmImage from '../../../public/assets/keith-combines-his-work-with-his-public-pensions-sm.jpg'
+import learnBannerImage from '../../../public/assets/learn-banner.jpg'
+import mainSourcesOfRetirementIncomeSmImage from '../../../public/assets/main-sources-of-retirement-income-sm.jpg'
+import planningToSaveForRetirementSmImage from '../../../public/assets/planning-to-save-for-retirement-sm.jpg'
+import rulesOfThumbForPublicPensionsSmImage from '../../../public/assets/rules-of-thumb-for-public-pensions-sm.jpg'
 import { HeroBanner } from '../../components/HeroBanner'
 import Layout from '../../components/Layout'
 import { getDCTermsTitle } from '../../utils/seo-utils'
@@ -16,19 +25,19 @@ interface LearnCardProps {
   desciption: string
   href: string
   id: string
-  imageUrl: string
+  imageSrc: StaticImageData
   minRead: number
   title: string
 }
 
-const LearnCard: FC<LearnCardProps> = ({ desciption, href, id, imageUrl, minRead, title }) => {
+const LearnCard: FC<LearnCardProps> = ({ desciption, href, id, imageSrc, minRead, title }) => {
   const { t } = useTranslation('learn')
   const uniqueId = useId()
   return (
     <Card id={`${uniqueId}-card-${id}`} className="h-full">
       <CardActionArea component={Link} href={href} className="h-full" aria-describedby={`${uniqueId}-card-${id}-title`}>
-        <div className="relative">
-          <CardMedia component="img" alt="" image={imageUrl} className="h-64 w-full object-cover" />
+        <div className="relative h-64 ">
+          <Image fill alt="" src={imageSrc} className="object-cover" placeholder="blur" />
           <Image src="/assets/bottom-top.svg" width={34} height={360} className="absolute bottom-0 w-full" alt="" />
         </div>
         <CardContent className="mt-4 p-8">
@@ -78,7 +87,7 @@ const Learn: FC = () => {
           desciption: t(`sections.learn-about.cards.sources-of-income.body`),
           href: '/learn/main-sources-of-retirement-income',
           id: 'sources-of-income',
-          imageUrl: '/assets/main-sources-of-retirement-income-sm.jpg',
+          imageSrc: mainSourcesOfRetirementIncomeSmImage,
           minRead: 15,
           title: t(`sections.learn-about.cards.sources-of-income.title`),
         },
@@ -86,7 +95,7 @@ const Learn: FC = () => {
           desciption: t(`sections.learn-about.cards.planning-to-save.body`),
           href: '/learn/planning-to-save-for-retirement',
           id: 'planning-to-save',
-          imageUrl: '/assets/planning-to-save-for-retirement-sm.jpg',
+          imageSrc: planningToSaveForRetirementSmImage,
           minRead: 5,
           title: t(`sections.learn-about.cards.planning-to-save.title`),
         },
@@ -101,7 +110,7 @@ const Learn: FC = () => {
           desciption: t(`sections.making-decisions.cards.when-to-start.body`),
           href: '/learn/deciding-when-to-start-your-public-pensions',
           id: 'when-to-start',
-          imageUrl: '/assets/deciding-when-to-start-your-public-pensions-sm.jpg',
+          imageSrc: decidingWhenToStartYourPublicPensionsSmImage,
           minRead: 15,
           title: t(`sections.making-decisions.cards.when-to-start.title`),
         },
@@ -109,7 +118,7 @@ const Learn: FC = () => {
           desciption: t(`sections.making-decisions.cards.from-work-to-retirement.body`),
           href: '/learn/going-from-work-to-retirement',
           id: 'from-work-to-retirement',
-          imageUrl: '/assets/going-from-work-to-retirement-sm.jpg',
+          imageSrc: goingFromWorkToRetirementSmImage,
           minRead: 10,
           title: t(`sections.making-decisions.cards.from-work-to-retirement.title`),
         },
@@ -117,7 +126,7 @@ const Learn: FC = () => {
           desciption: t(`sections.making-decisions.cards.rules-of-thumb.body`),
           href: '/learn/rules-of-thumb-for-public-pensions',
           id: 'rules-of-thumb',
-          imageUrl: '/assets/rules-of-thumb-for-public-pensions-sm.jpg',
+          imageSrc: rulesOfThumbForPublicPensionsSmImage,
           minRead: 9,
           title: t(`sections.making-decisions.cards.rules-of-thumb.title`),
         },
@@ -132,7 +141,7 @@ const Learn: FC = () => {
           desciption: t(`sections.stories.cards.fred.body`),
           href: '/learn/case-studies/fred',
           id: 'fred',
-          imageUrl: '/assets/fred-decides-when-to-take-his-pensions-sm.jpg',
+          imageSrc: fredDecidesWhenToTakeHisPensionsSmImage,
           minRead: 17,
           title: t(`sections.stories.cards.fred.title`),
         },
@@ -140,7 +149,7 @@ const Learn: FC = () => {
           desciption: t(`sections.stories.cards.bonnie.body`),
           href: '/learn/case-studies/bonnie',
           id: 'bonnie',
-          imageUrl: '/assets/bonnie-delays-to-reduce-the-savings-she-needs-sm.jpg',
+          imageSrc: bonnieDelaysToReduceTheSavingsSheNeedsSmImage,
           minRead: 20,
           title: t(`sections.stories.cards.bonnie.title`),
         },
@@ -148,7 +157,7 @@ const Learn: FC = () => {
           desciption: t(`sections.stories.cards.keith.body`),
           href: '/learn/case-studies/keith',
           id: 'keith',
-          imageUrl: '/assets/keith-combines-his-work-with-his-public-pensions-sm.jpg',
+          imageSrc: keithCombinesHisWorkWithHisPublicPensionsSmImage,
           minRead: 17,
           title: t(`sections.stories.cards.keith.title`),
         },
@@ -171,15 +180,7 @@ const Learn: FC = () => {
           },
         ]}
       >
-        <HeroBanner
-          imageProps={{
-            alt: '',
-            className: 'md:object-right-bottom',
-            height: 427,
-            src: '/assets/learn-banner.jpg',
-            width: 640,
-          }}
-        >
+        <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: learnBannerImage }}>
           <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
             {t('banner.title')}
           </h1>


### PR DESCRIPTION
### Description

List of proposed changes:

-  image placeholder blur for banners and cards images.

### Additional Notes

It's using the local images import. Next.js will automatically determine the width and height of your image based on the imported file. These values are used to prevent Cumulative Layout Shift while your image is loading.

https://nextjs.org/docs/pages/api-reference/components/image#local-images

Blurred images
![image](https://github.com/DTS-STN/senior-journey/assets/114004123/0a235134-3473-456f-b660-e7374e2e440e)
