### PR TITLE
[frontend] add focus visible indicator to TOC button

### DIFF
--- a/frontend/src/components/TableOfContentsDialog.tsx
+++ b/frontend/src/components/TableOfContentsDialog.tsx
@@ -50,7 +50,7 @@ export const TableOfContentsDialog: FC<TableOfContentsDialogProps> = ({ header, 
 
   return (
     <>
-      <Fab aria-label={t('table-of-contents.dialog.trigger-aria-label')} onClick={handleOnTriggerClick}>
+      <Fab aria-label={t('table-of-contents.dialog.trigger-aria-label')} onClick={handleOnTriggerClick} className='focus-visible:ring-4 focus-visible:ring-primary-500'>
         <TocIcon />
       </Fab>
       <Dialog open={open} onClose={handleOnDialogClose} fullScreen={fullScreen}>


### PR DESCRIPTION
Add a focus visible indicator to the table of contents button on learn pages.  This indicator should be visible when the component receives keyboard focus:

How it looks:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/098c1ef9-43c2-46a3-b43f-5c2c47e0d776)
