### PR TITLE
Checklist Accordion Bug and Formatting

### DIFF
--- a/frontend/src/components/TaskAccordion.tsx
+++ b/frontend/src/components/TaskAccordion.tsx
@@ -34,13 +34,13 @@ export const TaskAccordion: FC<TaskAccordionProps> = (props) => {
   }, [handleOnDetailsToggle])
 
   return (
-    <details ref={detailsRef} className="group/task divide-y transition-transform sm:ml-4 " open={expanded}>
-      <summary className="flex cursor-pointer gap-2 px-4 py-5 font-display text-lg font-medium focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary-700 sm:pl-0">
+    <details ref={detailsRef} className="group/task divide-y transition-transform sm:ml-4" open={expanded}>
+      <summary className="flex cursor-pointer gap-2 px-4 pb-3 pt-7 font-display text-lg font-medium outline-none focus-visible:ring-2 focus-visible:ring-primary-700 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:pl-0">
         <Checkbox className="-mt-2.5 hidden print:inline" />
         <h3 className="grow">{title}</h3>
         <ExpandMoreIcon className="self-center text-black/50 transition-transform group-open/task:rotate-180" />
       </summary>
-      <section className="p-4 sm:pl-14">
+      <section className="p-4 sm:pl-10">
         <TaskCard linksHeader={linksHeader} showCheckbox={false} srTag={srTag} task={props} />
       </section>
     </details>

--- a/frontend/src/components/TaskGroupAccordion.tsx
+++ b/frontend/src/components/TaskGroupAccordion.tsx
@@ -59,7 +59,7 @@ export const TaskGroupAccordion: React.FC<TaskGroupAccordionProps> = ({
         open={disabled ? false : expanded}
         data-gc-analytics-expand={sectionTitle}
       >
-        <summary className="flex cursor-pointer  gap-2 bg-primary-800 px-4 py-5 text-white focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary-700 group-aria-disabled/task-group:pointer-events-none group-aria-disabled/task-group:select-none">
+        <summary className="flex cursor-pointer gap-2 bg-primary-800 px-4 py-5 text-white outline-none focus-visible:ring-2 focus-visible:ring-primary-700 focus-visible:ring-offset-2 focus-visible:ring-offset-white group-aria-disabled/task-group:pointer-events-none group-aria-disabled/task-group:select-none">
           <div className="grow">
             <h2 className="mb-2 font-display text-xl font-bold">{sectionTitle}</h2>
             <p className="m-0 text-sm text-white/70">{subSectionTitle}</p>

--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -5,7 +5,6 @@ import Print from '@mui/icons-material/Print'
 import {
   Button,
   Checkbox,
-  Collapse,
   FormControlLabel,
   FormGroup,
   IconButton,
@@ -168,23 +167,23 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               </Button>
             </div>
             <div className="mb-4">
-              <div className="mb-2 flex items-center justify-between border-b pb-3">
-                <Button
-                  variant="text"
-                  color="primary"
-                  className="font-display text-xl"
-                  onClick={() => setImportantExpanded(!importantExpanded)}
-                  aria-expanded={importantExpanded}
-                  aria-label={t('important-terms.show')}
-                  endIcon={importantExpanded ? <ExpandLess /> : <ExpandMore />}
-                  sx={{ justifyContent: 'space-between' }}
-                  fullWidth
-                  size="large"
-                >
-                  {t('important-terms.header')}
-                </Button>
-              </div>
-              <Collapse in={importantExpanded}>
+              <details open={importantExpanded}>
+                <summary tabIndex={-1} className="mb-2 flex items-center justify-between border-b pb-3">
+                  <Button
+                    variant="text"
+                    color="primary"
+                    className="font-display text-xl"
+                    onClick={() => setImportantExpanded(!importantExpanded)}
+                    aria-expanded={importantExpanded}
+                    aria-label={t('important-terms.show')}
+                    endIcon={importantExpanded ? <ExpandLess /> : <ExpandMore />}
+                    sx={{ justifyContent: 'space-between' }}
+                    fullWidth
+                    size="large"
+                  >
+                    {t('important-terms.header')}
+                  </Button>
+                </summary>
                 <List className="p-0" disablePadding>
                   {[
                     {
@@ -210,40 +209,43 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
                     </ListItem>
                   ))}
                 </List>
-              </Collapse>
+              </details>
             </div>
 
             <div className="md:mb-2">
-              <div className="flex items-center justify-between md:mb-2 md:border-b md:pb-3">
-                <div className="text-2xl md:hidden">{t('header')}</div>
-                {!desktop && (
-                  <IconButton
-                    color="primary"
-                    onClick={() => setExpanded(!expanded)}
-                    aria-expanded={expanded}
-                    aria-label={t('show-filters')}
-                  >
-                    <FilterList className="h-10 w-10 rounded-full bg-[#008490] p-1 text-white hover:bg-[#00545f]" />
-                  </IconButton>
-                )}
-                {desktop && (
-                  <Button
-                    variant="text"
-                    color="primary"
-                    className="font-display text-xl"
-                    onClick={() => setExpanded(!expanded)}
-                    aria-expanded={expanded}
-                    aria-label={t('show-filters')}
-                    endIcon={expanded ? <ExpandLess /> : <ExpandMore />}
-                    sx={{ justifyContent: 'space-between' }}
-                    fullWidth
-                    size="large"
-                  >
-                    {t('filter-tasks', { count: filters.tags.length })}
-                  </Button>
-                )}
-              </div>
-              <Collapse in={expanded}>
+              <details open={expanded}>
+                <summary
+                  tabIndex={-1}
+                  className="flex items-center justify-between font-display text-xl md:mb-2 md:border-b md:pb-3"
+                >
+                  <div className="text-2xl md:hidden">{t('header')}</div>
+                  {!desktop && (
+                    <IconButton
+                      color="primary"
+                      onClick={() => setExpanded(!expanded)}
+                      aria-expanded={expanded}
+                      aria-label={t('show-filters')}
+                    >
+                      <FilterList className="h-10 w-10 rounded-full bg-[#008490] p-1 text-white hover:bg-[#00545f]" />
+                    </IconButton>
+                  )}
+                  {desktop && (
+                    <Button
+                      variant="text"
+                      color="primary"
+                      className="font-display text-xl"
+                      onClick={() => setExpanded(!expanded)}
+                      aria-expanded={expanded}
+                      aria-label={t('show-filters')}
+                      endIcon={expanded ? <ExpandLess /> : <ExpandMore />}
+                      sx={{ justifyContent: 'space-between' }}
+                      fullWidth
+                      size="large"
+                    >
+                      {t('filter-tasks', { count: filters.tags.length })}
+                    </Button>
+                  )}
+                </summary>
                 <FormGroup onChange={handleChange} data-cy="form-group-filter-tasks">
                   {tagsFilter.map(({ code, title }) => (
                     <FormControlLabel
@@ -253,7 +255,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
                     />
                   ))}
                 </FormGroup>
-              </Collapse>
+              </details>
             </div>
             <div className="hidden lg:block">
               <Button onClick={handlePrint} variant="outlined" startIcon={<Print />} className="font-bold">
@@ -261,7 +263,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               </Button>
             </div>
           </section>
-          <section id="content" className="print-href grid gap-4 lg:col-span-8 xl:col-span-9">
+          <section id="content" className="print-href flex flex-col gap-4 lg:col-span-8 xl:col-span-9">
             <TaskGroupAccordion
               expanded={expandedGroups.includes(beforeRetiring.id)}
               expandedTasks={expandedTasks}


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/xxx)

### Description

List of proposed changes:

- Checklist page bug where if the Important Terms and Filter Tasks section were opened first they would cause the accordions to open as well has been fixed. Can be re-produced by opening one of these sections while accordions are closed
- Added transition effect on the Accordion opening (not sure if this was removed intentionally?)
- Removed focus outline on accordion for consistency with other Collapse elements

### What to test for/How to test

### Additional Notes
- Fresh PR