### PR TITLE
[frontend] open-telemetry setup

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -75,7 +75,6 @@ COPY --chown=node:node --from=builder /home/node/public ./public
 COPY --chown=node:node --from=builder /home/node/.next ./.next
 COPY --chown=node:node --from=builder /home/node/next.config.js ./next.config.js
 COPY --chown=node:node --from=builder /home/node/next-i18next.config.js ./next-i18next.config.js
-COPY --chown=node:node --from=builder /home/node/open-telemetry.config.js ./open-telemetry.config.js
 COPY --chown=node:node --from=builder /home/node/package*.json ./
 
 USER node

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-require('./open-telemetry.config')
-
 const { i18n } = require('./next-i18next.config')
 const { statSync } = require('fs')
 
@@ -25,6 +23,9 @@ const nextConfig = {
     NEXT_PUBLIC_BUILD_TIMESTAMP: new Date(process.env.BUILD_DATE ?? statSync('package.json').mtime).toISOString(),
     NEXT_PUBLIC_BUILD_VERSION: process.env.BUILD_VERSION ?? '00000000-0000-00000000',
     LOGGING_LEVEL: process.env.LOGGING_LEVEL ?? 'info',
+  },
+  experimental: {
+    instrumentationHook: true
   },
   generateBuildId: async () => (process.env.BUILD_ID ?? '0000'),
   headers: async () => ([{ source: '/:path*', headers: securityHeaders }]),

--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -1,0 +1,5 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./instrumentation.node')
+  }
+}


### PR DESCRIPTION
### Description

List of proposed changes:

- open-telemetry setup using instrumentation hook

### Additional Notes

Doing it that way fixes @sebastien-comeau issues when stopping next dev process. He has terminal piling over and over and could only stop them manually with task manager. Implemented Next.js OpenTelemetry guide fixed the issue.

https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry