### PR TITLE
[frontend] add autoWidthColumn prop to a11y table

### DIFF
--- a/frontend/src/components/AccessibilityGraphContainer.tsx
+++ b/frontend/src/components/AccessibilityGraphContainer.tsx
@@ -10,6 +10,7 @@ export interface AccessibilityGraphContainerProps {
   descriptionHeading: string
   valuesHeading: string
   buttonLabel: string
+  autoWidthColumns?: boolean
 }
 
 const AccessibilityGraphContainer: FC<AccessibilityGraphContainerProps> = ({

--- a/frontend/src/components/AccessibilityTable.tsx
+++ b/frontend/src/components/AccessibilityTable.tsx
@@ -6,6 +6,7 @@ export interface TableData {
   rows: {
     data: string[]
   }[]
+  autoWidthColumns?: boolean
 }
 
 interface TableProps {
@@ -20,7 +21,11 @@ const AccessibilityTable: React.FC<TableProps> = ({ tableData }) => {
         <thead className="bg-gray-surface font-display text-xl">
           <tr className="divide-x">
             {tableData.header.map((headerItem, index) => (
-              <th scope="col" key={`${index}-${headerItem}`} className="w-[150px] px-3 py-2.5">
+              <th
+                scope="col"
+                key={`${index}-${headerItem}`}
+                className={`${tableData.autoWidthColumns ? 'w-full' : 'w-[150px]'} px-3 py-2.5`}
+              >
                 {headerItem}
               </th>
             ))}

--- a/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
+++ b/frontend/src/pages/learn/main-sources-of-retirement-income.tsx
@@ -354,6 +354,7 @@ const MainSourcesOfRetirementIncome: FC = () => {
             rows: t('canada-pension-plan-program.cpp-post-retirement-benefit.chart.accessibility.rows', {
               returnObjects: true,
             }),
+            autoWidthColumns: true,
           }}
           description={t(
             'canada-pension-plan-program.cpp-post-retirement-benefit.chart.accessibility.description.content'


### PR DESCRIPTION
The intent of this PR is to address comments from the design team and the testing team for the Main Source of Retirement Income page accessibility table.  

Here is the discourse from Slack:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/8a3e540e-036d-4286-af4b-2f5971b0793f)


The end result is that by adding an optional boolean flag to the accessibility table props, we can surgically control the width of the table columns.  This is absolutely ground breaking code right here, enjoy...