### PR TITLE
Update French Banner Text Size

### DIFF
--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -84,7 +84,7 @@ const Home: FC = () => {
       <Layout contained={false}>
         <Container className="mb-8 md:mb-12">
           <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: landingPageImage }}>
-            <h1 className={`mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 ${locale === 'en' ? 'md:text-6xl' : 'md:text-4xl lg:text-6xl'}`}>
+            <h1 className='mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-4xl lg:text-6xl'>
               {t('banner.title')}
             </h1>
             <p className="m-0">{t('banner.text')}</p>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -84,7 +84,7 @@ const Home: FC = () => {
       <Layout contained={false}>
         <Container className="mb-8 md:mb-12">
           <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: landingPageImage }}>
-            <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
+            <h1 className={`mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 ${locale === 'en' ? 'md:text-6xl' : 'md:text-4xl lg:text-6xl'}`}>
               {t('banner.title')}
             </h1>
             <p className="m-0">{t('banner.text')}</p>
@@ -190,7 +190,7 @@ const Home: FC = () => {
                       <p>{t('tabs.learn.description.stories')}</p>
                       <Divider className="my-8" />
                       <div className="text-right">
-                        <Button component={Link} href="/learn" size="large">
+                        <Button component={Link} href="/learn" size="large" className='text-center'>
                           {t('tabs.learn.button-text')}
                         </Button>
                       </div>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -190,7 +190,7 @@ const Learn: FC = () => {
         ]}
       >
         <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: learnBannerImage }}>
-        <h1 className={`mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 ${locale === 'en' ? 'md:text-6xl' : 'md:text-4xl lg:text-6xl'}`}>
+        <h1 className='mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-4xl lg:text-6xl'>
             {t('banner.title')}
           </h1>
           <p>{t('banner.text')}</p>

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -20,7 +20,6 @@ import rulesOfThumbForPublicPensionsSmImage from '../../../public/assets/rules-o
 import { HeroBanner } from '../../components/HeroBanner'
 import Layout from '../../components/Layout'
 import { getDCTermsTitle } from '../../utils/seo-utils'
-import { useRouter } from 'next/router'
 
 interface LearnCardProps {
   desciption: string

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -83,7 +83,6 @@ const LearnSection: FC<LearnSectionProps> = ({ cards, desciption, id, title }) =
 
 const Learn: FC = () => {
   const { t } = useTranslation('learn')
-  const { locale } = useRouter()
 
   const sections: ReadonlyArray<LearnSectionProps> = [
     {

--- a/frontend/src/pages/learn/index.tsx
+++ b/frontend/src/pages/learn/index.tsx
@@ -20,6 +20,7 @@ import rulesOfThumbForPublicPensionsSmImage from '../../../public/assets/rules-o
 import { HeroBanner } from '../../components/HeroBanner'
 import Layout from '../../components/Layout'
 import { getDCTermsTitle } from '../../utils/seo-utils'
+import { useRouter } from 'next/router'
 
 interface LearnCardProps {
   desciption: string
@@ -83,6 +84,7 @@ const LearnSection: FC<LearnSectionProps> = ({ cards, desciption, id, title }) =
 
 const Learn: FC = () => {
   const { t } = useTranslation('learn')
+  const { locale } = useRouter()
 
   const sections: ReadonlyArray<LearnSectionProps> = [
     {
@@ -188,11 +190,11 @@ const Learn: FC = () => {
         ]}
       >
         <HeroBanner imageProps={{ className: 'md:object-right-bottom', src: learnBannerImage }}>
-          <h1 className="mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 md:text-6xl">
+        <h1 className={`mb-2 font-display text-4xl font-bold text-primary-700 md:mb-4 ${locale === 'en' ? 'md:text-6xl' : 'md:text-4xl lg:text-6xl'}`}>
             {t('banner.title')}
           </h1>
           <p>{t('banner.text')}</p>
-          <Button component={Link} id="quiz-dialog-link" size="large" href="/quiz">
+          <Button component={Link} id="quiz-dialog-link" size="large" href="/quiz" className='text-center'>
             {t('banner.quiz')}
           </Button>
         </HeroBanner>


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/JourneyLab/SeniorsJourney/_workitems/edit/xxx)

### Description

List of proposed changes:

- French banner text is too long to be 6xl in md viewports see images for changes
- Button text aligned center
Before:
![image](https://github.com/DTS-STN/senior-journey/assets/53541292/62939a89-d9a1-4915-802f-17a2402f5b02)

After:
![image](https://github.com/DTS-STN/senior-journey/assets/53541292/c9855d98-865f-4590-ae40-c0b2e85050fc)


### What to test for/How to test

### Additional Notes