### PR TITLE
[frontend] contain underline quiz buttons

### DIFF
--- a/frontend/src/components/quiz/questions/QuestionWhere.tsx
+++ b/frontend/src/components/quiz/questions/QuestionWhere.tsx
@@ -60,26 +60,30 @@ export const QuestionWhere: FC<QuestionWhereProps> = ({ values, setFieldValue })
           aria-label={t('questions.question-where.option-canada-pt-60-or-more')}
           data-cy="canada-pt-60-or-more-button"
         >
-          <Trans
-            i18nKey="questions.question-where.option-canada-pt-60-or-more"
-            ns="quiz"
-            components={{
-              span: <span className="underline-offset-2 px-1 underline"/>,
-            }}
-        />
+          <div>
+            <Trans
+              i18nKey="questions.question-where.option-canada-pt-60-or-more"
+              ns="quiz"
+              components={{
+                span: <span className="px-1 underline underline-offset-2" />,
+              }}
+            />
+          </div>
         </ToggleButton>
         <ToggleButton
           value="canada-pt-less-than-60"
           aria-label={t('questions.question-where.option-canada-pt-less-than-60')}
           data-cy="canada-pt-less-than-60-button"
         >
-          <Trans
-            i18nKey="questions.question-where.option-canada-pt-less-than-60"
-            ns="quiz"
-            components={{
-              span: <span className="underline-offset-2 px-1 underline" />,
-            }}
-          />
+          <div>
+            <Trans
+              i18nKey="questions.question-where.option-canada-pt-less-than-60"
+              ns="quiz"
+              components={{
+                span: <span className="px-1 underline underline-offset-2" />,
+              }}
+            />
+          </div>
         </ToggleButton>
         <ToggleButton
           value="outside-canada"


### PR DESCRIPTION
This PR aims to address the issue of certain quiz buttons have text wrap when the viewport is small:

The first button shows the after and the second button shows the before:

![image](https://github.com/DTS-STN/senior-journey/assets/48450599/2b14d829-2f19-44c8-bfc4-fe5f85e42168)
