### PR TITLE
[frontend] remove data-gc-analytics-tabopen

### DIFF
--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -94,30 +94,10 @@ const Home: FC = () => {
             <Paper elevation={4} square className="relative">
               {!extraSmall && (
                 <TabList onChange={handleChange} scrollButtons="auto" centered>
-                  <Tab
-                    value="learn"
-                    label={t('tabs.learn.title')}
-                    data-gc-analytics-tabopen={t('tabs.learn.title')}
-                    className="px-10 pt-4 text-lg md:text-2xl"
-                  />
-                  <Tab
-                    value="plan"
-                    label={t('tabs.plan.title')}
-                    data-gc-analytics-tabopen={t('tabs.plan.title')}
-                    className="px-10 pt-4 text-lg md:text-2xl"
-                  />
-                  <Tab
-                    value="apply"
-                    label={t('tabs.apply.title')}
-                    data-gc-analytics-tabopen={t('tabs.apply.title')}
-                    className="px-10 pt-4 text-lg md:text-2xl"
-                  />
-                  <Tab
-                    value="manage"
-                    label={t('tabs.manage.title')}
-                    data-gc-analytics-tabopen={t('tabs.manage.title')}
-                    className="px-10 pt-4 text-lg md:text-2xl"
-                  />
+                  <Tab value="learn" label={t('tabs.learn.title')} className="px-10 pt-4 text-lg md:text-2xl" />
+                  <Tab value="plan" label={t('tabs.plan.title')} className="px-10 pt-4 text-lg md:text-2xl" />
+                  <Tab value="apply" label={t('tabs.apply.title')} className="px-10 pt-4 text-lg md:text-2xl" />
+                  <Tab value="manage" label={t('tabs.manage.title')} className="px-10 pt-4 text-lg md:text-2xl" />
                 </TabList>
               )}
               {extraSmall && (
@@ -150,25 +130,12 @@ const Home: FC = () => {
                         },
                       }}
                     >
-                      <Tab
-                        value="learn"
-                        label={t('tabs.learn.title')}
-                        data-gc-analytics-tabopen={t('tabs.learn.title')}
-                      />
-                      <Tab value="plan" label={t('tabs.plan.title')} data-gc-analytics-tabopen={t('tabs.plan.title')} />
+                      <Tab value="learn" label={t('tabs.learn.title')} />
+                      <Tab value="plan" label={t('tabs.plan.title')} />
                       ,
-                      <Tab
-                        value="apply"
-                        label={t('tabs.apply.title')}
-                        data-gc-analytics-tabopen={t('tabs.apply.title')}
-                      />
+                      <Tab value="apply" label={t('tabs.apply.title')} />
                       ,
-                      <Tab
-                        value="manage"
-                        label={t('tabs.manage.title')}
-                        data-gc-analytics-tabopen={t('tabs.manage.title')}
-                      />
-                      ,
+                      <Tab value="manage" label={t('tabs.manage.title')} />,
                     </TabList>
                   </Collapse>
                 </>
@@ -192,9 +159,7 @@ const Home: FC = () => {
                       </div>
                     </Paper>
                     <Paper className="p-8 md:w-4/6">
-                      <h3 className="h3 h3-gutter-bottom">
-                        {t('tabs.learn.linksTitle')}
-                      </h3>
+                      <h3 className="h3 h3-gutter-bottom">{t('tabs.learn.linksTitle')}</h3>
                       <List disablePadding>
                         <ListItem disablePadding className="border-b">
                           <ListItemButton href="/learn/deciding-when-to-start-your-public-pensions" component={Link}>
@@ -259,9 +224,7 @@ const Home: FC = () => {
                       </div>
                     </Paper>
                     <Paper className="p-8 md:w-4/6">
-                      <h3 className="h3 h3-gutter-bottom">
-                        {t('tabs.plan.linksTitle')}
-                      </h3>
+                      <h3 className="h3 h3-gutter-bottom">{t('tabs.plan.linksTitle')}</h3>
                       <List disablePadding className="ml-4">
                         <ListItem disablePadding className="border-b">
                           <ListItemButton


### PR DESCRIPTION
Remove `data-gc-analytics-tabopen` attribute on home page per AA team request.