### PR TITLE
[frontend] add logic to open/close tasks on print

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -268,7 +268,3 @@ main .external-link[target='_blank']::after {
   width: 1em;
   text-align: center;
 }
-
-.page-nav-active {
-  @apply bg-[#4ED8E8] bg-opacity-[12%] text-[#008490];
-}


### PR DESCRIPTION
## Note [22 June 2023]
I'm putting this in draft since the requirements have changed based on requests from the design team.  This issue with the approach taken in this PR is that it will expand ALL groups/tasks, when the desired behaviour is to be able to toggle all groups/tasks open via a button, and then subsequently collapse groups/tasks the user doesn't want printed.  In other words, this PR only allows for all accordions open in the print, and the user perhaps wants or needs finer control over the printed document.

---

This PR aims to solve the issue of opening all tasks on print.  When printing is finished, all tasks that weren't previously opened should be closed, but the ones that were open should remain open.  This also applies to the 3 timeline summaries.

Inspiration found [here](https://stackoverflow.com/a/75260733)

Also removed an unused style in the global css.