### PR TITLE
[frontend] add open/close all tasks logic

### DIFF
--- a/frontend/public/locales/en/checklist.json
+++ b/frontend/public/locales/en/checklist.json
@@ -2,6 +2,8 @@
   "breadcrumbs": {
     "learn": "Learn"
   },
+  "open-all": "Open all tasks",
+  "close-all": "Close all tasks",
   "filter-tasks_zero": "Filter tasks",
   "filter-tasks_one": "Filter tasks ({{count}} applied)",
   "filter-tasks_other": "Filter tasks ({{count}} applied)",

--- a/frontend/public/locales/fr/checklist.json
+++ b/frontend/public/locales/fr/checklist.json
@@ -2,6 +2,8 @@
   "breadcrumbs": {
     "learn": "Apprendre"
   },
+  "open-all": "Ouvrir toutes les tâches",
+  "close-all": "Fermer toutes les tâches",
   "filter-tasks_zero": "Sélection des tâches",
   "filter-tasks_one": "Sélection des tâches ({{count}} sélectionnée)",
   "filter-tasks_other": "Sélection des tâches ({{count}} sélectionnées)",

--- a/frontend/src/pages/checklist/[filters].tsx
+++ b/frontend/src/pages/checklist/[filters].tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FC, MouseEvent, useMemo, useState } from 'react'
 
-import { Cached, ExpandLess, ExpandMore, FilterList } from '@mui/icons-material'
+import { Cached, ExpandLess, ExpandMore, FilterList, UnfoldMore } from '@mui/icons-material'
 import Print from '@mui/icons-material/Print'
 import {
   Button,
@@ -61,6 +61,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
   const [importantExpanded, setImportantExpanded] = useState(false)
   const [expandedGroups, setExpandedGroups] = useState(initialExpandedGroups)
   const [expandedTasks, setExpandedTasks] = useState(initialExpandedTasks)
+  const [allExpanded, setAllExpanded] = useState(false)
 
   const desktop = useMediaQuery(theme.breakpoints.up('md'))
 
@@ -123,6 +124,27 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
       scroll: false,
       shallow: true,
     })
+  }
+
+  function handleAllExpandedToggle() {
+    if (allExpanded) {
+      setExpandedGroups([])
+      setExpandedTasks([])
+    } else {
+      setExpandedGroups([beforeRetiring.id, applyingBenefits.id, receivingBenefits.id])
+      setExpandedTasks(
+        [...beforeRetiring.tasks, ...applyingBenefits.tasks, ...receivingBenefits.tasks].map((t) => t.id)
+      )
+    }
+    setAllExpanded((prev) => !prev)
+    router.replace(
+      { pathname: router.pathname, query: { ...router.query, group: expandedGroups, task: expandedTasks } },
+      undefined,
+      {
+        scroll: false,
+        shallow: true,
+      }
+    )
   }
 
   return (
@@ -257,9 +279,17 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
                 </FormGroup>
               </details>
             </div>
-            <div className="hidden lg:block">
+            <div className="hidden lg:flex lg:flex-wrap lg:gap-6">
               <Button onClick={handlePrint} variant="outlined" startIcon={<Print />} className="font-bold">
                 {t('print')}
+              </Button>
+              <Button
+                onClick={handleAllExpandedToggle}
+                variant="outlined"
+                startIcon={<UnfoldMore />}
+                className="font-bold"
+              >
+                {t(allExpanded ? 'close-all' : 'open-all')}
               </Button>
             </div>
           </section>
@@ -300,7 +330,7 @@ const ChecklistResults: FC<ChecklistResultsProps> = ({
               srTag={t('sr-tag')}
               tasks={receivingBenefits.tasks.filter((task) => filterTasksByTag(task, filters))}
             />
-            <div className="mt-4 lg:hidden">
+            <div className="mt-4 print:hidden lg:hidden">
               <Button
                 variant="text"
                 startIcon={<Cached />}


### PR DESCRIPTION
This PR is based on the latest requests from the Design Team in relation to adding a feature to open all tasks on demand, and subsequently close all tasks on demand.  

This is a screenshot of the requirements from the Design Team as of 21 June 2023:
![image](https://github.com/DTS-STN/senior-journey/assets/48450599/f064e7b7-0722-47d1-8ce1-0b2bef6cee98)

## Changes
- add open/close button beside the print button to toggle the task/group state to either be open or closed
- update the url based on expanded groups, tasks, and filters
- hide the print button when the page is in print mode