### PR TITLE
[frontend] Change error links to go to /en and /fr

### DIFF
--- a/frontend/src/components/error-pages/Error404Page.tsx
+++ b/frontend/src/components/error-pages/Error404Page.tsx
@@ -32,7 +32,7 @@ const Error404Page: FC = () => {
           <ul className="list-disc space-y-1 pl-7">
             <li>
               Return to the{' '}
-              <MuiLink component={Link} href="/" locale="default">
+              <MuiLink component={Link} href="/" locale="en">
                 home page
               </MuiLink>
               ;
@@ -52,7 +52,7 @@ const Error404Page: FC = () => {
           <ul className="list-disc space-y-1 pl-7">
             <li>
               Retournez à la{' '}
-              <MuiLink component={Link} href="/" locale="default">
+              <MuiLink component={Link} href="/" locale="fr">
                 page d&#39;accueil
               </MuiLink>
               ;

--- a/frontend/src/components/error-pages/ErrorPage.tsx
+++ b/frontend/src/components/error-pages/ErrorPage.tsx
@@ -41,7 +41,7 @@ const ErrorPage: FC<ErrorPageProps> = ({ statusCode }) => {
             <li>Try refreshing the page or try again later;</li>
             <li>
               Return to the{' '}
-              <MuiLink component={Link} href="/" locale="default">
+              <MuiLink component={Link} href="/" locale="en">
                 home page
               </MuiLink>
               ;
@@ -64,7 +64,7 @@ const ErrorPage: FC<ErrorPageProps> = ({ statusCode }) => {
             <li>Actualisez la page ou réessayez plus tard;</li>
             <li>
               Retournez à la{' '}
-              <MuiLink component={Link} href="/" locale="default">
+              <MuiLink component={Link} href="/" locale="fr">
                 page d&#39;accueil
               </MuiLink>
               ;


### PR DESCRIPTION
Changing error pages to go to /en/home and /fr/home instead of the language chooser page.