### PR TITLE
fix(fontend): quiz-form-state-mapper missing skip answer

### DIFF
--- a/frontend/__tests__/lib/mappers/quiz-form-state-mapper.test.ts
+++ b/frontend/__tests__/lib/mappers/quiz-form-state-mapper.test.ts
@@ -1,0 +1,132 @@
+import { getAnswer, getAnswers, toChecklistFilter } from '../../../src/lib/mappers/quiz-form-state-mapper'
+
+describe('getAnswer', () => {
+  test('returns the skipAnswer when the answer is empty', () => {
+    // arrange
+    const answer = ''
+    const skipAnswer = 'kids-skip'
+
+    // act
+    const act = getAnswer(answer, skipAnswer)
+
+    // assert
+    expect(act).toBe(skipAnswer)
+  })
+
+  test('returns the answer when the answer is not empty', () => {
+    // arrange
+    const answer = 'answer'
+    const skipAnswer = 'kids-skip'
+
+    // act
+    const act = getAnswer(answer, skipAnswer)
+
+    // assert
+    expect(act).toBe(answer)
+  })
+})
+
+describe('getAnswers', () => {
+  it.each([{ answers: [] }, { answers: [''] }, { answers: ['', ''] }])(
+    'returns an array with the skipAnswer when answers is empty; answers: $answers',
+    ({ answers }) => {
+      // arrange
+      const skipAnswer = 'marital-status-skip'
+
+      // act
+      const act = getAnswers(answers, skipAnswer)
+
+      // assert
+      expect(act).toEqual([skipAnswer])
+    }
+  )
+
+  test('returns a compacted array of answers when answers is not empty', () => {
+    // arrange
+    const answers = ['answer-one', '', 'answer-two', '']
+    const skipAnswer = 'marital-status-skip'
+
+    // act
+    const result = getAnswers(answers, skipAnswer)
+
+    // assert
+    expect(result).toEqual(['answer-one', 'answer-two'])
+  })
+})
+
+describe('toChecklistFilter', () => {
+  test('returns the correct checklist filters with non-empty values', () => {
+    // arrange
+    const state = {
+      divorcedOrSeparated: 'divorced-or-separated-answer',
+      financialPreparedness: 'financial-preparedness-answer',
+      hasChildren: 'has-children-answer',
+      hasCppDisabilityBenefits: 'has-cpp-disability-benefits-answer',
+      hasExtraIncome: 'has-extra-income-answer',
+      legalStatus: 'legal-status-answer',
+      marriedOrCommonLaw: 'married-or-common-law-answer',
+      retirementAge: 'retirement-age-answer',
+      retirementTimeframe: 'retirement-timeframe-answer',
+      single: 'single-answer',
+      widowed: 'widowed-answer',
+      yearsInCanada: 'years-in-canada-answer',
+    }
+
+    // act
+    const act = toChecklistFilter(state)
+
+    // assert
+    const expected = [
+      'divorced-or-separated-answer',
+      'financial-preparedness-answer',
+      'has-children-answer',
+      'has-cpp-disability-benefits-answer',
+      'has-extra-income-answer',
+      'legal-status-answer',
+      'married-or-common-law-answer',
+      'retirement-age-answer',
+      'retirement-timeframe-answer',
+      'single-answer',
+      'widowed-answer',
+      'years-in-canada-answer',
+    ]
+    expect(act.answers).toEqual(expect.arrayContaining(expected))
+    expect(act.answers.length).toEqual(expected.length)
+  })
+
+  test('returns the correct checklist filters with empty values', () => {
+    // arrange
+    const state = {
+      divorcedOrSeparated: '',
+      financialPreparedness: '',
+      hasChildren: '',
+      hasCppDisabilityBenefits: '',
+      hasExtraIncome: '',
+      legalStatus: '',
+      marriedOrCommonLaw: '',
+      retirementAge: '',
+      retirementTimeframe: '',
+      single: '',
+      widowed: '',
+      yearsInCanada: '',
+    }
+
+    // act
+    const act = toChecklistFilter(state)
+
+    // assert
+    const expected = [
+      'cppd-skip',
+      'in-canada-skip',
+      'income-skip',
+      'kids-skip',
+      'marital-status-skip',
+      'preparedness-skip',
+      'retirement-age-skip',
+      'retirement-living-skip',
+      'status-skip',
+    ]
+    expect(act.answers).toEqual(expect.arrayContaining(expected))
+    expect(act.answers.length).toEqual(expected.length)
+  })
+})

--- a/frontend/src/lib/mappers/quiz-form-state-mapper.ts
+++ b/frontend/src/lib/mappers/quiz-form-state-mapper.ts
@@ -13,12 +13,12 @@ type SkipAnswer =
   | 'retirement-living-skip'
   | 'status-skip'
 
-const getAnswer = (answer: string, skipAnswer: SkipAnswer) => {
+export const getAnswer = (answer: string, skipAnswer: SkipAnswer) => {
   return isEmpty(answer) ? skipAnswer : answer
 }
 
-const getAnswers = (answers: Array<string>, skipAnswer: SkipAnswer) => {
-  return isEmpty(answers) ? [skipAnswer] : compact(answers)
+export const getAnswers = (answers: Array<string>, skipAnswer: SkipAnswer) => {
+  return isEmpty(compact(answers)) ? [skipAnswer] : compact(answers)
 }
 
 export const toChecklistFilter = (state: QuizFormState): ChecklistFilters => {


### PR DESCRIPTION
### Description

List of proposed changes:

- fix(fontend): quiz-form-state-mapper missing skip answer
- writtend quiz-form-state-mapper unit tests

### Additional Notes

There was a bug with `getAnswers` that affected the `marital-status-skip` when the array of anwers value was empty.