### PR TITLE
fix: CVE-2023-32002

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ ARG BUILD_ID=0000
 ARG BUILD_REVISION=00000000
 ARG BUILD_VERSION=19700101-0000-00000000
 
-FROM docker.io/node:18.14.2-bullseye-slim AS base
+FROM docker.io/node:18.17.1-bullseye-slim AS base
 
 
 


### PR DESCRIPTION
### Description

 CVE-2023-32002 hsa been flagged by Dynatrace as Critical.

List of proposed changes:

- fix: CVE-2023-32002

### Additional Notes

Node version 18.17.1 have fixes for CVE-2023-32002
https://github.com/nodejs/node/releases/tag/v18.17.1