### PR TITLE
[frontend] bump sharp

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11967,9 +11967,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.32.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.5.tgz",
-      "integrity": "sha512-0dap3iysgDkNaPOaOL4X/0akdu0ma62GcdC2NBQ+93eqpePdDdr2/LM0sFdDSMmN7yS+odyZtPsb7tx/cYBKnQ==",
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",


### PR DESCRIPTION
Bump sharp to 0.32.6 to address [Vulnerability in libwebp dependency, please upgrade sharp to 0.32.6 (CVE-2023-4863) ](https://github.com/lovell/sharp/issues/3798)