### PR TITLE
Bump docker base image to 20.9.0-bookworm-slim

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ ARG BUILD_ID=0000
 ARG BUILD_REVISION=00000000
 ARG BUILD_VERSION=19700101-0000-00000000
 
-FROM docker.io/node:20.8.1-bullseye-slim AS base
+FROM docker.io/node:20.9.0-bookworm-slim AS base
 
 
 


### PR DESCRIPTION
### Description

List of proposed changes:

- Bump docker base image to 20.9.0-bookworm-slim