### PR TITLE
fix(frontend): handle urlcat error

### DIFF
--- a/frontend/src/next-seo.config.ts
+++ b/frontend/src/next-seo.config.ts
@@ -3,6 +3,10 @@ import { OpenGraphMedia } from 'next-seo/lib/types'
 import { Router } from 'next/router'
 import urlcat from 'urlcat'
 
+import { getLogger } from './logging/log-util'
+
+const logger = getLogger('next-seo-config')
+
 export type NextSEORouter = Pick<Router, 'asPath' | 'locale'>
 
 export interface LanguageAlternate {
@@ -12,19 +16,27 @@ export interface LanguageAlternate {
 
 export const getLanguageAlternates = (
   appBaseUri: string,
-  router: NextSEORouter
+  router: NextSEORouter,
 ): ReadonlyArray<LanguageAlternate> | undefined => {
   if (!appBaseUri) return
-  return [
-    {
-      hrefLang: 'en',
-      href: urlcat(appBaseUri, `/en${router.asPath}`),
-    },
-    {
-      hrefLang: 'fr',
-      href: urlcat(appBaseUri, `/fr${router.asPath}`),
-    },
-  ]
+  try {
+    return [
+      {
+        hrefLang: 'en',
+        href: urlcat(appBaseUri, `/en${router.asPath}`),
+      },
+      {
+        hrefLang: 'fr',
+        href: urlcat(appBaseUri, `/fr${router.asPath}`),
+      },
+    ]
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Unable to perform operation getLanguageAlternates due to: ${error.message}`
+        : `Unknown error occurred`
+    logger.error(error, message)
+  }
 }
 
 export const getOpenGraphImages = (appBaseUri: string): ReadonlyArray<OpenGraphMedia> | undefined => {


### PR DESCRIPTION
### Description

List of proposed changes:

- fix(frontend): handle urlcat error

### What to test for/How to test

Url pathname with `/actuator/jolokia/search/*:test=test` was throwing an error when calling urlcat when the page responded with error 500 and should return a 404.

### Additional Notes

{
  "level": 50,
  "time": "2023-12-20T00:13:28.904Z",
  "pid": 1364,
  "hostname": "...",
  "name": "next-seo-config",
  "err": {
    "type": "Error",
    "message": "Missing value for path parameter test.",
    "stack": "Error: Missing value for path parameter test.\n    at validatePathParam (file:///C:/data/projects/DTS-STN/senior-journey/frontend/node_modules/urlcat/dist/index.mjs:77:11)\n    at file:///C:/data/projects/DTS-STN/senior-journey/frontend/node_modules/urlcat/dist/index.mjs:68:5\n    at String.replace (<anonymous>)\n    at path (file:///C:/data/projects/DTS-STN/senior-journey/frontend/node_modules/urlcat/dist/index.mjs:66:33)\n    at urlcatImpl (file:///C:/data/projects/DTS-STN/senior-journey/frontend/node_modules/urlcat/dist/index.mjs:43:45)\n    at urlcat (file:///C:/data/projects/DTS-STN/senior-journey/frontend/node_modules/urlcat/dist/index.mjs:25:12)\n    at l (C:\\data\\projects\\DTS-STN\\senior-journey\\frontend\\.next\\server\\chunks\\900.js:1:2221)\n    at u (C:\\data\\projects\\DTS-STN\\senior-journey\\frontend\\.next\\server\\chunks\\900.js:1:3967)\n    at p (C:\\data\\projects\\DTS-STN\\senior-journey\\frontend\\.next\\server\\chunks\\900.js:1:6113)\n    at C:\\data\\projects\\DTS-STN\\senior-journey\\frontend\\.next\\server\\chunks\\900.js:1:6965"
  },
  "msg": "Unable to perform operation due to Missing value for path parameter test."
}
