### PR TITLE
Fix nodejs versions

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ ARG BUILD_ID=0000
 ARG BUILD_REVISION=00000000
 ARG BUILD_VERSION=19700101-0000-00000000
 
-FROM docker.io/node:22.6.0-bookworm-slim AS base
+FROM docker.io/node:20.17.0-bookworm-slim AS base
 
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@types/jest": "29.5.12",
         "@types/jest-axe": "3.5.9",
         "@types/lodash": "4.17.7",
-        "@types/node": "20.12.7",
+        "@types/node": "20.16.4",
         "@types/react": "18.3.3",
         "ajv": "8.12.0",
         "ajv-formats": "3.0.1",
@@ -3452,11 +3452,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.4.tgz",
+      "integrity": "sha512-ioyQ1zK9aGEomJ45zz8S8IdzElyxhvP1RVWnPrXDf6wFaUb+kk1tEcVVJkF7RPGM0VWI7cp5U57oCPIn5iN1qg==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/parse-json": {
@@ -4167,9 +4167,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -13532,9 +13532,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "29.5.12",
     "@types/jest-axe": "3.5.9",
     "@types/lodash": "4.17.7",
-    "@types/node": "20.12.7",
+    "@types/node": "20.16.4",
     "@types/react": "18.3.3",
     "ajv": "8.12.0",
     "ajv-formats": "3.0.1",


### PR DESCRIPTION
NodeJS was accidentally bumped past the LTS version in a dependabot PR. This reverts that and updates node to the latest container image and typescript types.